### PR TITLE
feat: MiMo 一键获取 Cookie 与多项 UI 修复 (v1.3.6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <p align="center">
   <img alt="Python 3.11+" src="https://img.shields.io/badge/Python-3.11%2B-3776AB?logo=python&amp;logoColor=white">
   <img alt="Windows 10/11" src="https://img.shields.io/badge/Windows-10%20%7C%2011-0078D4?logo=windows&amp;logoColor=white">
-  <img alt="Version 1.3.5" src="https://img.shields.io/badge/version-1.3.5-2f6fe4">
+  <img alt="Version 1.3.6" src="https://img.shields.io/badge/version-1.3.6-2f6fe4">
 </p>
 
 TokenSpider 是一个面向 Windows 的 AI 平台用量监控工具。程序常驻系统托盘，以悬浮球展示核心数据；点击后可展开完整面板，查看余额、今日与本周用量、费用趋势、模型统计和过去一年的活跃记录。支持 DeepSeek 与 小米 Mimo 两个平台，可在设置中切换。
@@ -74,7 +74,7 @@ python main.py
 2. 打开「设置」 → 在「数据来源」下拉列表中选择 **DeepSeek** 或 **小米 MiMo**。
 3. 填写对应平台的凭据：
    - **DeepSeek**：Bearer Token 或 Cookie；如有官方 API Key 可一并填写
-   - **小米 MiMo**：登录 `platform.xiaomimimo.com` 后复制浏览器请求中的**完整 Cookie**（通常包含 `api-platform_serviceToken`、`userId`、`api-platform_slh`、`api-platform_ph`）；Cookie 中的 `api-platform_ph` 会被自动提取并回填到对应输入框，无需手动复制粘贴第二次
+   - **小米 MiMo**：登录 `platform.xiaomimimo.com` 后复制浏览器请求中的**完整 Cookie**（通常包含 `api-platform_serviceToken`、`userId`、`api-platform_slh`、`api-platform_ph`）；Cookie 中的 `api-platform_ph` 会被自动提取并回填到对应输入框，无需手动复制粘贴第二次。也可直接在凭据区域点击「一键获取 MiMo Cookie」，按提示拉起本机 Chrome 完成登录后回填。
 4. 保存设置并执行刷新。
 
 默认刷新间隔为 60 秒。切换平台后，面板会立即进入该平台自己的未配置、加载、成功或失败状态，不会短暂展示上一平台数据。
@@ -145,11 +145,25 @@ TokenSpider/
 ## 故障排查
 
 - **提示尚未配置**：在设置中选择提供商（DeepSeek / 小米 MiMo）并填写对应凭据。
-- **提示凭据失效**：重新获取并保存当前账户的 Token 或 Cookie；**小米 MiMo 需同时更新 `api-platform_ph`，且程序会从粘贴的整段 Cookie 中自动提取 `api-platform_ph`，无需手动复制到独立输入框**。
+- **提示凭据失效**：重新获取并保存当前账户的 Token 或 Cookie；**小米 MiMo 需同时更新 `api-platform_ph`，且程序会从粘贴的整段 Cookie 中自动提取 `api-platform_ph`，无需手动复制到独立输入框**。也可在凭据区域点击「一键获取 MiMo Cookie」，由程序拉起本机浏览器读取 Cookie。
 - **提示请求过于频繁或平台风控拒绝请求**：等待一段时间后再手动刷新；不要持续缩短刷新间隔。
 - **数据暂时没有更新**：程序会继续显示上一次成功获取的缓存，可查看 `%APPDATA%\TokenSpider\TokenSpider.log` 获取详细信息。
 - **程序没有出现窗口**：检查系统托盘；TokenSpider 只允许一个实例运行。
 - **大数字显示过长**：≥ 1 亿的 Token 会以「亿」为单位显示，无需额外处理。
+
+## v1.3.6
+
+- 设置中选择小米 MiMo 时，凭据区新增「一键获取 MiMo Cookie」与「完成采集」，程序通过 CDP 协议拉起本机 Chrome，在用户登录 MiMo 控制台后自动读取 Cookie 并回填到输入框，避免反复复制粘贴。
+- 一键获取使用独立 Chrome 进程（``--user-data-dir`` 指向 ``%APPDATA%/TokenSpider/mimo-chrome``），不会影响用户平时的浏览会话；若未识别到 Chrome，会在状态提示中给出可执行路径配置位置。
+- 修复 CDP WebSocket 握手在 ``--app`` 模式下因响应头文案差异而被误判为失败的问题：状态码改为 ``101`` 匹配；并放宽对 target 类型的限制，同时接受 ``page`` / ``app`` / ``background_page`` / ``other``。
+- 改用 ``Network.getAllCookies`` 获取整个浏览器上下文中的 Cookie，避免仅拿当前页面域的 Cookie 时为空。
+- 采集完成后改用 CDP 的 ``Browser.close`` 让 Chrome 自行优雅退出，确保本次登录态写入独立用户数据目录，后续再次点击「一键获取」时可直接使用已登录会话；仅在浏览器 10 秒内仍未退出时回退 ``kill()``，防止进程泄漏。
+- 获取 Cookie 后在设置面板里同时把 Cookie 与 ``api-platform_ph`` 填到对应输入框，并把值同步到内部草稿，保证「保存」时生效；不再因为输入框已有旧值而跳过回填。
+- ``_format_cookie_string`` 放宽了 ``domain`` 过滤，允许 ``xiaomimimo.com`` 任意子域，并对 ``api-platform_ph`` 值去外层引号；``_url`` 在拼接 ``api-platform_ph`` 前同样会去引号，避免把 ``"`` 带进去导致 404。
+- 新增 `MiMoProvider.normalize_cookie / extract_cookie_value / _cdp_send_text / acquire_cookie_via_chrome / describe_acquire_error` 方法，便于外部调用。
+- 补充 ``tests/test_providers.py`` 中针对 Cookie 规范化、``api-platform_ph`` 提取、target 选取逻辑、``_cdp_send_text`` 容错和未识别 Chrome 时错误信息的回归测试（共 18 项）。
+- 修复面板和设置窗口继承悬浮球的 ``WindowStaysOnTopHint`` 标志导致所有应用被压在下面的问题：展开面板和打开设置时去掉置顶，收回悬浮球时恢复置顶。
+- 修复展开面板后点击其它应用时面板被自动回收的问题：移除 ``WindowDeactivate`` 触发的自动 ``collapse_panel`` 逻辑，面板回收仅通过 ESC 键、关闭按钮或点击悬浮球触发。
 
 ## v1.3.5
 

--- a/api/providers/mimo.py
+++ b/api/providers/mimo.py
@@ -3,11 +3,27 @@
 Uses the platform API at ``platform.xiaomimimo.com`` to fetch balance,
 monthly usage summary, and per-day usage details — all authenticated via
 browser cookie.
+
+A ``acquire_cookie_via_chrome`` helper is provided so the settings dialog
+can launch the user's own Chrome/Edge and let them log in through the
+browser, then return the required ``api-platform_*`` cookie strings
+directly back into the credential UI. That helper uses only the Python
+standard library (``subprocess``, ``http.client``, ``socket``, ``json``)
+and does not require Playwright or any third-party package.
 """
 
 from __future__ import annotations
 
+import http.client
+import json
+import os
+import socket
+import struct
+import subprocess
+import threading
+from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import requests
 
@@ -22,6 +38,23 @@ from api.providers.base import (
 )
 
 _MIMO_PLATFORM = "https://platform.xiaomimimo.com"
+# 浏览器获取 Cookie 时打开的目标页面。
+MIMO_ACQUIRE_URL = f"{_MIMO_PLATFORM}/console/usage"
+# 需要从浏览器上下文中提取的 cookie 名称；与 cookie_tool 保持一致。
+MIMO_ACQUIRE_KEYS = (
+    "api-platform_ph",
+    "api-platform_serviceToken",
+    "api-platform_slh",
+    "userId",
+)
+# 匹配 ``domain`` 字段；MiMo 平台 cookie 落在平台域名或其子域上。
+MIMO_ACQUIRE_DOMAINS = ("platform.xiaomimimo.com", ".xiaomimimo.com", ".platform.xiaomimimo.com")
+# CDP 随机调试端口探测区间。
+_MIMO_CDP_PORT_RANGE = range(9222, 9323)
+# CDP 握手超时（秒），避免线程被阻塞太久。
+_MIMO_CDP_TIMEOUT_SECONDS = 10
+# Cookie 采集总超时（秒），兜底防止 worker 长时间不退出。
+_MIMO_ACQUIRE_TOTAL_TIMEOUT_SECONDS = 180
 
 
 class MiMoProvider(Provider):
@@ -100,6 +133,465 @@ class MiMoProvider(Provider):
             or str(config_manager.get("MIMO_API_KEY", "")).strip()
         )
 
+    # --------------------------------------------------------- chrome helpers
+    @staticmethod
+    def default_user_data_dir() -> str:
+        """返回浏览器独立用户数据目录（默认 ``%APPDATA%/TokenSpider/mimo-chrome``）。"""
+        base = os.environ.get("APPDATA") or str(Path.home() / "AppData" / "Roaming")
+        return str(Path(base) / "TokenSpider" / "mimo-chrome")
+
+    @staticmethod
+    def find_chrome_executable(use_edge: bool = False) -> str:
+        """探测本机 Chrome（或 Edge）可执行文件路径。找不到返回空串。"""
+        candidates: list[str] = []
+        # 优先 Windows 注册表：App Paths 里记录了常见浏览器路径。
+        try:
+            import winreg  # 仅 Windows 可用，PyInstaller 打包后仍可用。
+            app_name = "msedge.exe" if use_edge else "chrome.exe"
+            with winreg.OpenKey(
+                winreg.HKEY_LOCAL_MACHINE,
+                rf"SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\{app_name}",
+            ) as key:
+                path, _ = winreg.QueryValueEx(key, "")
+                if path and os.path.isfile(path):
+                    candidates.append(path)
+        except (FileNotFoundError, OSError, PermissionError):
+            pass
+        except Exception:
+            pass
+        # 常见安装位置兜底；在 Windows 10/11 上 Chrome 可能装在 Program Files
+        # 或 %LOCALAPPDATA%，Edge 装在 Program Files。
+        local_appdata = os.environ.get("LOCALAPPDATA") or str(Path.home() / "AppData" / "Local")
+        program_files = [
+            os.environ.get("ProgramFiles", r"C:\Program Files"),
+            os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"),
+        ]
+        if use_edge:
+            for base in program_files:
+                candidates.append(str(Path(base) / "Microsoft" / "Edge" / "Application" / "msedge.exe"))
+        else:
+            for base in program_files:
+                candidates.append(str(Path(base) / "Google" / "Chrome" / "Application" / "chrome.exe"))
+            candidates.append(str(Path(local_appdata) / "Google" / "Chrome" / "Application" / "chrome.exe"))
+        for path in candidates:
+            if path and os.path.isfile(path):
+                return path
+        return ""
+
+    @staticmethod
+    def pick_free_cdp_port() -> int:
+        """在 ``_MIMO_CDP_PORT_RANGE`` 里随机选一个空闲端口；找不到返回 -1。"""
+        for port in _MIMO_CDP_PORT_RANGE:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                try:
+                    sock.bind(("127.0.0.1", port))
+                    return port
+                except OSError:
+                    continue
+        return -1
+
+    @staticmethod
+    def _http_json(host: str, port: int, path: str, timeout: float) -> Any:
+        """对调试端口做一次简单 HTTP GET 并返回 JSON。"""
+        conn = http.client.HTTPConnection(host, port, timeout=timeout)
+        try:
+            conn.request("GET", path)
+            resp = conn.getresponse()
+            data = resp.read()
+        finally:
+            conn.close()
+        if resp.status != 200:
+            raise RuntimeError(f"CDP_HTTP_{resp.status}")
+        try:
+            return json.loads(data.decode("utf-8", errors="replace"))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise RuntimeError("CDP_INVALID_JSON") from exc
+
+    @staticmethod
+    def _wait_browser_ready(port: int, stop_event: threading.Event, timeout: float = 15.0) -> None:
+        """等待调试端口返回 200，否则抛 ``RuntimeError``。"""
+        deadline = threading.Event()
+        timer = threading.Timer(timeout, lambda: deadline.set())
+        timer.daemon = True
+        timer.start()
+        try:
+            while not stop_event.is_set() and not deadline.is_set():
+                try:
+                    MiMoProvider._http_json("127.0.0.1", port, "/json/version", 1.0)
+                    return
+                except (OSError, RuntimeError, http.client.HTTPException):
+                    stop_event.wait(0.25)
+            raise RuntimeError("BROWSER_NOT_READY")
+        finally:
+            timer.cancel()
+
+    @staticmethod
+    def _pick_websocket_endpoint(port: int) -> str:
+        """获取 CDP 中可用 target 对应的 WebSocket 端点。
+
+        Chrome 对 ``--app`` 模式可能把 URL 记在 ``page``、``app`` 或
+        ``background_page`` 类型中，因此不能只用 ``type == "page"``。
+        """
+        items = MiMoProvider._http_json("127.0.0.1", port, "/json", _MIMO_CDP_TIMEOUT_SECONDS)
+        if not isinstance(items, list):
+            raise RuntimeError("CDP_UNEXPECTED_JSON")
+        acceptable = {"page", "app", "background_page", "other"}
+        candidate = None
+        for entry in items:
+            if not isinstance(entry, dict):
+                continue
+            kind = entry.get("type")
+            url = entry.get("url") or ""
+            ws = entry.get("webSocketDebuggerUrl")
+            if not ws:
+                continue
+            if kind in acceptable:
+                # 优先挑一个属于目标站点的 target；没有则选第一个可用。
+                if _MIMO_PLATFORM in url:
+                    return str(ws)
+                if candidate is None:
+                    candidate = str(ws)
+        if candidate:
+            return candidate
+        raise RuntimeError("CDP_NO_PAGE_TARGET")
+
+    @staticmethod
+    def _cdp_fetch_cookies_via_ws(ws_url: str) -> list[dict[str, Any]]:
+        """通过 CDP WebSocket 发送 ``Network.getAllCookies`` 并返回 cookies 列表。
+
+        说明
+        ----
+        - Chrome ``--app`` 模式下响应头为 ``101 WebSocket Protocol Handshake``，
+          因此只检查状态码是否为 ``101`` 而不是 ``"101 Switching Protocols"``。
+        - ``Network.getCookies`` 受当前页面域限制，可能返回空；改用
+          ``Network.getAllCookies`` 拿到整个浏览器上下文中的 cookie，与
+          ``cookie_tool`` 中 ``context.cookies()`` 的行为保持一致。
+        """
+        parsed = urlparse(ws_url)
+        if parsed.scheme != "ws" or not parsed.hostname or not parsed.port:
+            raise RuntimeError("CDP_INVALID_WS_URL")
+        host = parsed.hostname
+        port = int(parsed.port)
+        path = parsed.path or "/"
+        if parsed.query:
+            path = f"{path}?{parsed.query}"
+        # 1) 做 HTTP 升级握手。RFC 6455 允许使用任意 16 字节 base64 串作 key，
+        #    这里采用固定值以避免引入额外依赖。
+        key_b64 = "dGhlIHNhbXBsZSBub25jZQ=="
+        request = (
+            f"GET {path} HTTP/1.1\r\n"
+            f"Host: {host}:{port}\r\n"
+            "Upgrade: websocket\r\n"
+            "Connection: Upgrade\r\n"
+            f"Sec-WebSocket-Key: {key_b64}\r\n"
+            "Sec-WebSocket-Version: 13\r\n"
+            "\r\n"
+        )
+        sock = socket.create_connection((host, port), timeout=_MIMO_CDP_TIMEOUT_SECONDS)
+        try:
+            sock.sendall(request.encode("ascii"))
+            # 读取响应头直到空行。
+            buf = bytearray()
+            while True:
+                chunk = sock.recv(2048)
+                if not chunk:
+                    raise RuntimeError("CDP_WS_HANDSHAKE_FAILED")
+                buf.extend(chunk)
+                if b"\r\n\r\n" in buf:
+                    break
+            head_end = buf.index(b"\r\n\r\n")
+            head_text = buf[:head_end].decode("ascii", errors="replace")
+            # Chrome / Chromium 的响应头形式因版本而异，核心是返回 ``101``。
+            if "101" not in head_text:
+                raise RuntimeError("CDP_WS_HANDSHAKE_FAILED")
+            # 2) 发送一个文本帧，请求 ``Network.getAllCookies``；相比
+            #    ``Network.getCookies``，它不受当前页面域限制，更稳定。
+            payload = json.dumps(
+                {"id": 1, "method": "Network.getAllCookies"},
+                ensure_ascii=False,
+            ).encode("utf-8")
+            # 文本帧：FIN=1, opcode=1, mask=1；使用 7 位长度（对 payload 足够）。
+            payload_len = len(payload)
+            if payload_len > 0xFFFF:
+                raise RuntimeError("CDP_PAYLOAD_TOO_LARGE")
+            header = bytearray()
+            header.append(0x81)  # FIN=1, opcode=1
+            header.append(0x80 | (payload_len & 0x7F))
+            masking_key = bytes(4)  # 零掩码即可
+            header.extend(masking_key)
+            # 客户端按协议必须 mask payload；这里 mask 是 0，mask 操作等价于不改动。
+            masked_payload = bytearray(payload)
+            for i in range(payload_len):
+                masked_payload[i] ^= masking_key[i % 4]
+            sock.sendall(bytes(header) + bytes(masked_payload))
+            # 3) 读取响应帧：期望一个 FIN=1 的文本帧；额外容忍 binary 与 0 长帧。
+            raw = MiMoProvider._recv_exact(sock, 2)
+            first_byte = raw[0]
+            fin = bool(first_byte & 0x80)
+            opcode = first_byte & 0x0F
+            second_byte = raw[1]
+            masked = bool(second_byte & 0x80)
+            length = second_byte & 0x7F
+            if not fin or opcode not in (1, 2):  # 1=text, 2=binary
+                raise RuntimeError("CDP_UNEXPECTED_FRAME")
+            if length == 126:
+                (length,) = struct.unpack(">H", MiMoProvider._recv_exact(sock, 2))
+            elif length == 127:
+                (length,) = struct.unpack(">Q", MiMoProvider._recv_exact(sock, 8))
+            if masked:
+                # 服务端理论上不应 mask；这里仍兼容处理以防万一。
+                key = MiMoProvider._recv_exact(sock, 4)
+            body = MiMoProvider._recv_exact(sock, length)
+            if masked:
+                body = bytes(b ^ key[i % 4] for i, b in enumerate(body))
+            try:
+                result = json.loads(body.decode("utf-8", errors="replace"))
+            except json.JSONDecodeError as exc:
+                raise RuntimeError("CDP_INVALID_JSON") from exc
+            if not isinstance(result, dict) or "result" not in result:
+                raise RuntimeError("CDP_UNEXPECTED_RESPONSE")
+            inner = result["result"]
+            # ``Network.getAllCookies`` 的返回字段名是 ``cookies``。
+            if not isinstance(inner, dict) or "cookies" not in inner:
+                raise RuntimeError("CDP_UNEXPECTED_RESPONSE")
+            cookies = inner["cookies"]
+            if not isinstance(cookies, list):
+                raise RuntimeError("CDP_UNEXPECTED_RESPONSE")
+            return cookies
+        finally:
+            try:
+                sock.close()
+            except OSError:
+                pass
+
+    @staticmethod
+    def _recv_exact(sock: socket.socket, n: int) -> bytes:
+        """从 ``sock`` 读 ``n`` 字节，不足则抛。"""
+        buf = bytearray()
+        while len(buf) < n:
+            chunk = sock.recv(n - len(buf))
+            if not chunk:
+                raise RuntimeError("CDP_CONN_CLOSED")
+            buf.extend(chunk)
+        return bytes(buf)
+
+    @staticmethod
+    def _format_cookie_string(cookies: list[dict[str, Any]]) -> str:
+        """把 CDP 读回的 cookies 列表按 ``MIMO_ACQUIRE_KEYS`` 顺序拼成一行。
+
+        为避免遗漏 ``api-platform_ph`` 这类可能落在 ``xiaomimimo.com``
+        子域上的 cookie，这里把 ``domain`` 判断放宽为「包含
+        ``xiaomimimo.com`` 的任意子域或主机名」，同时仍然严格按
+        ``MIMO_ACQUIRE_KEYS`` 过滤字段名，避免把无关的第三方 cookie
+        拼进请求头。
+        """
+        name_to_value: dict[str, str] = {}
+        for cookie in cookies:
+            if not isinstance(cookie, dict):
+                continue
+            name = str(cookie.get("name") or "")
+            if name not in MIMO_ACQUIRE_KEYS:
+                continue
+            domain = str(cookie.get("domain") or "").lower()
+            # 宽松判断：只要包含 xiaomimimo.com 主机部分，就视为来自 MiMo。
+            if domain and "xiaomimimo.com" not in domain:
+                continue
+            value = str(cookie.get("value") or "")
+            # ``api-platform_ph`` 有时会被百分编码；我们在拼到请求头里之前做
+            # 一次去引号处理，但保留原字符串，避免把 ``%2F`` 这类合法编码弄坏。
+            if len(value) >= 2 and value.startswith('"') and value.endswith('"'):
+                value = value[1:-1]
+            # 避免被后面的同字段、但值为空的 cookie 覆盖。
+            if value or name not in name_to_value:
+                name_to_value[name] = value
+        parts = [f"{k}={name_to_value.get(k, '')}" for k in MIMO_ACQUIRE_KEYS if k in name_to_value]
+        return "; ".join(parts)
+
+    @staticmethod
+    def _cdp_send_text(ws_url: str, payload: dict[str, Any]) -> None:
+        """建立 WebSocket 握手后发送一个 ``text`` 帧并立即关闭连接。
+
+        仅用于触发 ``Browser.close`` 这类「发送后立即关闭」的 CDP 命令，
+        不读响应；读响应走 ``_cdp_fetch_cookies_via_ws``。
+        """
+        parsed = urlparse(ws_url)
+        if parsed.scheme != "ws" or not parsed.hostname or not parsed.port:
+            return
+        host = parsed.hostname
+        port = int(parsed.port)
+        path = parsed.path or "/"
+        if parsed.query:
+            path = f"{path}?{parsed.query}"
+        request = (
+            f"GET {path} HTTP/1.1\r\n"
+            f"Host: {host}:{port}\r\n"
+            "Upgrade: websocket\r\n"
+            "Connection: Upgrade\r\n"
+            "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+            "Sec-WebSocket-Version: 13\r\n"
+            "\r\n"
+        )
+        try:
+            sock = socket.create_connection((host, port), timeout=_MIMO_CDP_TIMEOUT_SECONDS)
+        except OSError:
+            return
+        try:
+            sock.sendall(request.encode("ascii"))
+            buf = bytearray()
+            while True:
+                chunk = sock.recv(2048)
+                if not chunk:
+                    return
+                buf.extend(chunk)
+                if b"\r\n\r\n" in buf:
+                    break
+            body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+            body_len = len(body)
+            if body_len > 0xFFFF:
+                return
+            header = bytearray()
+            header.append(0x81)
+            header.append(0x80 | (body_len & 0x7F))
+            header.extend(bytes(4))
+            try:
+                sock.sendall(bytes(header) + body)
+            except OSError:
+                return
+        finally:
+            try:
+                sock.close()
+            except OSError:
+                pass
+
+    @staticmethod
+    def acquire_cookie_via_chrome(
+        stop_event: threading.Event,
+        use_edge: bool = False,
+        user_data_dir: str | None = None,
+    ) -> str:
+        """拉起本机 Chrome/Edge → 用户登录 → 读回 MiMo cookie。
+
+        说明
+        ----
+        - 为了让 ``--user-data-dir`` 保留登录态，退出浏览器使用 CDP 的
+          ``Browser.close``，让 Chrome 自行优雅退出并把 Cookie 刷盘；
+          仅当它在 10 秒内仍未退出时才回退 ``kill()``，避免进程泄漏。
+        """
+        exe = MiMoProvider.find_chrome_executable(use_edge=use_edge)
+        if not exe:
+            raise RuntimeError("CHROME_NOT_FOUND")
+        if user_data_dir:
+            data_dir = Path(user_data_dir)
+        else:
+            data_dir = Path(MiMoProvider.default_user_data_dir())
+        try:
+            data_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            raise RuntimeError("USER_DATA_DIR_FAILED") from exc
+        port = MiMoProvider.pick_free_cdp_port()
+        if port < 0:
+            raise RuntimeError("NO_FREE_CDP_PORT")
+        args = [
+            exe,
+            f"--user-data-dir={data_dir}",
+            f"--remote-debugging-port={port}",
+            "--remote-debugging-address=127.0.0.1",
+            "--no-first-run",
+            "--disable-default-apps",
+            f"--app={MIMO_ACQUIRE_URL}",
+        ]
+        startupinfo = None
+        creationflags = 0
+        try:
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+        except AttributeError:
+            startupinfo = None
+        process: subprocess.Popen[Any] | None = None
+        try:
+            process = subprocess.Popen(
+                args,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                stdin=subprocess.DEVNULL,
+                startupinfo=startupinfo,
+                creationflags=creationflags,
+            )
+        except OSError as exc:
+            raise RuntimeError("CHROME_LAUNCH_FAILED") from exc
+        ws_url_for_close: str | None = None
+        try:
+            MiMoProvider._wait_browser_ready(port, stop_event, timeout=15.0)
+            # 等待用户点击『完成采集』；同时带总超时防止进程泄漏。
+            stop_event.wait(timeout=_MIMO_ACQUIRE_TOTAL_TIMEOUT_SECONDS)
+            ws_url = MiMoProvider._pick_websocket_endpoint(port)
+            ws_url_for_close = ws_url
+            cookies = MiMoProvider._cdp_fetch_cookies_via_ws(ws_url)
+            raw = MiMoProvider._format_cookie_string(cookies)
+            if not raw:
+                raise RuntimeError("MIMO_COOKIE_EMPTY")
+            return MiMoProvider.normalize_cookie(raw)
+        except RuntimeError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError("ACQUIRE_UNEXPECTED") from exc
+        finally:
+            # 先让 Chrome 自己优雅退出（通过 CDP 发 ``Browser.close``），
+            # 这样它会把本次登录态写入 ``user-data-dir``。
+            if ws_url_for_close is not None:
+                try:
+                    MiMoProvider._cdp_send_text(
+                        ws_url_for_close,
+                        {"id": 1, "method": "Browser.close"},
+                    )
+                except Exception:  # noqa: BLE001
+                    pass
+            if process is not None:
+                try:
+                    # 给 Chrome 留一点时间写盘；期间若进程已退出就立即返回。
+                    process.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    try:
+                        process.terminate()
+                    except OSError:
+                        pass
+                    try:
+                        process.wait(timeout=3)
+                    except subprocess.TimeoutExpired:
+                        try:
+                            process.kill()
+                        except OSError:
+                            pass
+                except OSError:
+                    try:
+                        process.kill()
+                    except OSError:
+                        pass
+
+    # ---------------------------------------------------------- chrome errors
+    ACQUIRE_ERROR_MESSAGES = {
+        "CHROME_NOT_FOUND": "未检测到 Chrome 或 Edge，请先安装浏览器，或手动粘贴 Cookie",
+        "USER_DATA_DIR_FAILED": "无法创建浏览器用户数据目录",
+        "NO_FREE_CDP_PORT": "无法分配调试端口（9222~9322）",
+        "CHROME_LAUNCH_FAILED": "浏览器启动失败，请检查权限或安全软件是否拦截",
+        "BROWSER_NOT_READY": "浏览器调试接口未就绪，请稍后重试",
+        "CDP_CONN_CLOSED": "浏览器调试连接意外关闭",
+        "CDP_WS_HANDSHAKE_FAILED": "浏览器调试握手失败",
+        "CDP_INVALID_JSON": "浏览器调试返回非 JSON 响应",
+        "CDP_UNEXPECTED_FRAME": "浏览器调试返回未预期帧类型",
+        "CDP_INVALID_RESPONSE": "浏览器调试返回 cookies 结构异常",
+        "CDP_UNEXPECTED_RESPONSE": "浏览器调试响应字段缺失",
+        "CDP_PAYLOAD_TOO_LARGE": "调试请求体积过大",
+        "CDP_HTTP_404": "调试接口未就绪（404）",
+        "MIMO_COOKIE_EMPTY": "当前浏览器会话尚未登录 MiMo，请登录后再采集",
+        "ACQUIRE_UNEXPECTED": "采集 Cookie 时出现未预期错误",
+    }
+
+    @classmethod
+    def describe_acquire_error(cls, exc: Exception) -> str:
+        code = str(exc) if isinstance(exc, RuntimeError) else "ACQUIRE_UNEXPECTED"
+        return cls.ACQUIRE_ERROR_MESSAGES.get(code, f"采集失败：{code}")
+
     def _base_url(self) -> str:
         custom = str(config_manager.get("MIMO_BASE", "")).strip()
         # 迁移早期版本默认指向 api.xiaomimimo.com；用量/余额端点只在 platform
@@ -118,7 +610,8 @@ class MiMoProvider(Provider):
         if not ph:
             ph = str(config_manager.get("MIMO_API_PLATFORM_PH", "")).strip()
             if ph:
-                ph_decoded = ph.replace("%2F", "/").replace("%3D", "=")
+                # 去外层引号，防止把 """" 拼到请求头里。
+                ph_decoded = ph.strip().strip('"').strip().replace("%2F", "/").replace("%3D", "=")
                 cookie = f'{cookie}; api-platform_ph="{ph_decoded}"'
         return {
             "accept": "*/*",
@@ -146,8 +639,8 @@ class MiMoProvider(Provider):
         """构造完整 URL，并在末尾附加 ``api-platform_ph``。
 
         ``ph`` 直接作为原始查询串附加，避免对用户从浏览器复制的百分
-        比编码（如 ``%2F``）被二次编码。如果 Cookie 中已包含
-        ``api-platform_ph``，则优先使用它，保持与请求头一致。
+        比编码（如 ``%2F``）被二次编码；但会去掉外层双引号，防止
+        拼到 URL 上时把 ``"`` 带进去导致 404。
         """
         base = self._base_url()
         url = f"{base}{path}"
@@ -155,6 +648,9 @@ class MiMoProvider(Provider):
         ph = self.extract_cookie_value(self.normalize_cookie(cookie_raw), "api-platform_ph")
         if not ph:
             ph = str(config_manager.get("MIMO_API_PLATFORM_PH", "")).strip()
+        if ph:
+            # 去引号并修剪空白，防止 URL 出现 "%22" 或空格导致 404。
+            ph = ph.strip().strip('"').strip()
         if ph:
             sep = "&" if "?" in url else "?"
             url = f"{url}{sep}api-platform_ph={ph}"

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -8,6 +8,7 @@ os.environ["APPDATA"] = str(Path.cwd() / ".test-appdata")
 from api.deepseek import APIError
 from api.providers.deepseek import DeepSeekProvider
 from api.providers.mimo import MiMoProvider
+import config_manager
 
 
 def response(payload, status=200):
@@ -236,6 +237,177 @@ class DeepSeekProviderTests(unittest.TestCase):
             MiMoProvider.extract_cookie_value('api-platform_ph="abc=="; userId=1', "api-platform_ph"),
             "abc==",
         )
+
+
+    @patch("api.providers.mimo.MiMoProvider.find_chrome_executable")
+    def test_acquire_cookie_fails_gracefully_when_no_chrome(self, find_executable: Mock) -> None:
+        find_executable.return_value = ""
+        import threading
+
+        with self.assertRaises(RuntimeError):
+            MiMoProvider.acquire_cookie_via_chrome(threading.Event())
+
+    def test_cookie_helper_handles_multiple_formats(self) -> None:
+        # 1) 单行 name=value; name2=value2
+        self.assertEqual(
+            MiMoProvider.extract_cookie_value(
+                "a=1; api-platform_ph=some-token; c=3", "api-platform_ph"
+            ),
+            "some-token",
+        )
+        # 2) 换行与多余空白
+        self.assertEqual(
+            MiMoProvider.extract_cookie_value("a=1;\n api-platform_ph=xxx;\nc=3", "api-platform_ph"),
+            "xxx",
+        )
+        # 3) 被双引号括住
+        self.assertEqual(
+            MiMoProvider.extract_cookie_value('api-platform_ph="abc=="; userId=1', "api-platform_ph"),
+            "abc==",
+        )
+        # 4) 不包含字段时返回空串
+        self.assertEqual(
+            MiMoProvider.extract_cookie_value("userId=1; other=2", "api-platform_ph"),
+            "",
+        )
+
+    def test_normalize_cookie_squeezes_whitespace(self) -> None:
+        self.assertEqual(
+            MiMoProvider.normalize_cookie("a=1; \n b=2 ; \n c=3"),
+            "a=1; b=2; c=3",
+        )
+        self.assertEqual(MiMoProvider.normalize_cookie(""), "")
+
+    @patch("api.providers.mimo.MiMoProvider.acquire_cookie_via_chrome")
+    def test_error_message_lookup(self, acquire_mock: Mock) -> None:
+        acquire_mock.side_effect = RuntimeError("CHROME_NOT_FOUND")
+        try:
+            acquire_mock()
+        except RuntimeError as exc:
+            message = MiMoProvider.describe_acquire_error(exc)
+            self.assertIn("Chrome", message)
+
+    def test_cdp_prefers_mimo_url_over_others(self) -> None:
+        """``_pick_websocket_endpoint`` 应优先选择 MiMo 域名下的 target。"""
+        fake_response = [
+            {
+                "type": "background_page",
+                "url": "chrome-extension://abc/background.html",
+                "webSocketDebuggerUrl": "ws://127.0.0.1:9288/devtools/page/A",
+            },
+            {
+                "type": "page",
+                "url": "https://platform.xiaomimimo.com/console/usage",
+                "webSocketDebuggerUrl": "ws://127.0.0.1:9288/devtools/page/B",
+            },
+            {
+                "type": "other",
+                "url": "https://example.com",
+                "webSocketDebuggerUrl": "ws://127.0.0.1:9288/devtools/page/C",
+            },
+        ]
+
+        captured: list[str] = []
+
+        def fake_http(host: str, port: int, path: str, timeout: float) -> object:  # noqa: ARG001
+            captured.append(path)
+            # 只有 ``/json`` 返回目标列表；其他路径 ``/json/version`` 也应返回合法 JSON。
+            if path == "/json":
+                return fake_response
+            return {"Browser": "Chrome/149"}
+
+        with patch.object(MiMoProvider, "_http_json", side_effect=fake_http):
+            got = MiMoProvider._pick_websocket_endpoint(9288)
+        self.assertEqual(got, "ws://127.0.0.1:9288/devtools/page/B")
+        self.assertIn("/json", captured)
+
+    def test_cdp_falls_back_to_first_acceptable_target(self) -> None:
+        """如果列表中没有 MiMo 域名，回退到第一个可用 target 而不是直接报错。"""
+        fake_response = [
+            {
+                "type": "background_page",
+                "url": "chrome-extension://abc/background.html",
+                "webSocketDebuggerUrl": "ws://127.0.0.1:9288/devtools/page/A",
+            },
+            {"type": "service_worker", "webSocketDebuggerUrl": "ws://127.0.0.1:9288/devtools/page/SW"},
+        ]
+
+        def fake_http(host: str, port: int, path: str, timeout: float) -> object:  # noqa: ARG001
+            return fake_response
+
+        with patch.object(MiMoProvider, "_http_json", side_effect=fake_http):
+            got = MiMoProvider._pick_websocket_endpoint(9288)
+        # ``service_worker`` 不在可接受集合内，只能取 background_page。
+        self.assertEqual(got, "ws://127.0.0.1:9288/devtools/page/A")
+
+    def test_cdp_raises_when_no_suitable_target(self) -> None:
+        """所有条目都没有 webSocketDebuggerUrl 时，应抛 ``CDP_NO_PAGE_TARGET``。"""
+        fake_response = [
+            {"type": "page", "url": "https://example.com"},
+            {"type": "other", "url": "about:blank"},
+        ]
+
+        def fake_http(host: str, port: int, path: str, timeout: float) -> object:  # noqa: ARG001
+            return fake_response
+
+        with patch.object(MiMoProvider, "_http_json", side_effect=fake_http):
+            with self.assertRaises(RuntimeError) as ctx:
+                MiMoProvider._pick_websocket_endpoint(9288)
+        self.assertEqual(str(ctx.exception), "CDP_NO_PAGE_TARGET")
+
+    def test_cdp_send_text_handles_broken_ws_url(self) -> None:
+        """``_cdp_send_text`` 不应因非法 URL 或 socket 问题抛异常。"""
+        # 非法 scheme 不会建立连接；方法应安静返回。
+        MiMoProvider._cdp_send_text("http://127.0.0.1:1", {"id": 1, "method": "Browser.close"})
+        # 端口不可用；``socket.create_connection`` 抛 OSError 被内部吞掉。
+        MiMoProvider._cdp_send_text(
+            "ws://127.0.0.1:1/devtools/page/0000", {"id": 1, "method": "Browser.close"}
+        )
+
+    def test_format_cookie_string_relaxes_domain_and_strips_quotes(self) -> None:
+        """``_format_cookie_string`` 必须能识别 ``xiaomimimo.com`` 任意子域，
+        并把 ``api-platform_ph`` 引号去掉；否则会导致请求头/URL 里
+        出现 ``""...""`` 或被 domain 过滤掉。
+        """
+        cookies = [
+            {"name": "api-platform_ph", "value": '"abc%2Fdef%3D123"', "domain": ".xiaomimimo.com"},
+            {"name": "api-platform_serviceToken", "value": "token-value", "domain": "platform.xiaomimimo.com"},
+            {"name": "userId", "value": "12345678", "domain": "xiaomimimo.com"},
+            {"name": "_ga", "value": "GA1.2.0", "domain": "xiaomimimo.com"},  # 非关键字段，忽略
+            {"name": "other_session", "value": "x", "domain": "other.example.com"},
+        ]
+        got = MiMoProvider._format_cookie_string(cookies)
+        # api-platform_ph 必须去引号，并保留原本的百分编码。
+        self.assertIn('api-platform_ph=abc%2Fdef%3D123', got)
+        # serviceToken 和 userId 必须被包含（落在 ``xiaomimimo.com`` 子域上）。
+        self.assertIn("api-platform_serviceToken=token-value", got)
+        self.assertIn("userId=12345678", got)
+        # 非关键字段不会出现在 cookie 中。
+        self.assertNotIn("_ga=", got)
+        self.assertNotIn("other_session=", got)
+
+    def test_url_strips_quotes_from_api_platform_ph(self) -> None:
+        """``_url`` 拼接 ``api-platform_ph`` 前应去掉外层引号，防止
+        query 里出现 ``"`` 字符导致 404。
+        """
+        provider = MiMoProvider()
+
+        class _ConfigCache(dict):
+            def get(self, key, default=""):  # type: ignore[override]
+                return super().get(key, default)
+
+        fake = _ConfigCache(MIMO_COOKIE='a=1; api-platform_ph="xx/yy==zz"; userId=8')
+        # 临时替换 ``config_manager`` 的读接口。
+        original = config_manager.get
+        try:
+            config_manager.get = fake.get  # type: ignore[method-assign]
+            url = provider._url("/api/v1/balance")
+        finally:
+            config_manager.get = original  # type: ignore[method-assign]
+        self.assertTrue(url.startswith("https://platform.xiaomimimo.com/api/v1/balance?api-platform_ph="))
+        # 不能出现双引号；原本的 "/" 和 "=" 必须保留。
+        self.assertNotIn('"', url)
+        self.assertIn("xx/yy==zz", url)
 
 
 if __name__ == "__main__":

--- a/ui/qt_settings.py
+++ b/ui/qt_settings.py
@@ -53,6 +53,44 @@ class ConnectionWorker(QThread):
         self.finished_with_data.emit(result)
 
 
+class _MiMoCookieWorker(QThread):
+    """负责实际拉起 Chrome 并通过 CDP 读回 MiMo Cookie。
+
+    线程在空闲状态会在浏览器进程打开后，持续等待主线程设置
+    ``stop_event``。一旦被设置，线程立即读取 cookie 并通过 ``success``
+    信号传出；中途若出现异常，则通过 ``error`` 信号传出错提示。
+    """
+
+    success = Signal(str)
+    error = Signal(str)
+
+    def __init__(self, parent=None, use_edge: bool = False):
+        super().__init__(parent)
+        import threading
+
+        self._stop_event = threading.Event()
+        self._use_edge = use_edge
+
+    def stop_and_collect(self) -> None:
+        self._stop_event.set()
+
+    def run(self) -> None:
+        from api.providers.mimo import MiMoProvider
+
+        try:
+            cookie = MiMoProvider.acquire_cookie_via_chrome(
+                self._stop_event,
+                use_edge=self._use_edge,
+            )
+        except RuntimeError as exc:
+            self.error.emit(MiMoProvider.describe_acquire_error(exc))
+            return
+        except Exception as exc:  # noqa: BLE001
+            self.error.emit(MiMoProvider.describe_acquire_error(exc))
+            return
+        self.success.emit(cookie)
+
+
 class SettingsWindow(QDialog):
     def __init__(
         self,
@@ -68,7 +106,9 @@ class SettingsWindow(QDialog):
         self.on_saved = on_saved
         self.update_controller = update_controller
         self._worker: ConnectionWorker | None = None
+        self._mimo_cookie_worker: "_MiMoCookieWorker | None" = None
         self._rendered_provider_id = ""
+        self._provider_widgets: dict[str, Union[QLineEdit, QPlainTextEdit]] = {}
         self._provider_drafts: dict[str, dict[str, str]] = {}
         self._test_config_backup: dict[str, Any] | None = None
 
@@ -237,6 +277,114 @@ class SettingsWindow(QDialog):
         target_height = min(content_size.height(), max_height)
         self.resize(target_width, target_height)
 
+    def _begin_mimo_cookie_acquire(self) -> None:
+        """用户点击『一键获取 MiMo Cookie』。
+
+        会尝试识别当前 provider 是否为 mimo，拉起浏览器并等待登录。但真正的
+        读取要等用户点『完成采集』后才进行。
+        """
+        if self._rendered_provider_id != "mimo":
+            return
+        acquire_button = getattr(self, "_mimo_acquire_button", None)
+        if acquire_button is None:
+            return
+        acquire_button.setEnabled(False)
+        acquire_button.setText("正在打开浏览器…")
+        status_label = getattr(self, "_mimo_status_label", None)
+        if status_label is not None:
+            status_label.setText("正在打开浏览器，请在浏览器中完成登录。")
+        worker = _MiMoCookieWorker(self, use_edge=False)
+        self._mimo_cookie_worker = worker
+        worker.success.connect(self._apply_mimo_cookie_from_acquired)
+        worker.error.connect(self._mimo_acquire_failed)
+        worker.finished.connect(self._cleanup_mimo_cookie_worker)
+        worker.start()
+        # 等 0.5 秒后切换状态：让浏览器打开后，用户可以点“完成采集”
+        try:
+            from PySide6.QtCore import QTimer
+
+            def _after_poll() -> None:
+                if self._mimo_cookie_worker is worker and worker.isRunning():
+                    finish_button = getattr(self, "_mimo_finish_button", None)
+                    if finish_button is not None:
+                        finish_button.setVisible(True)
+                        finish_button.setEnabled(True)
+                button_text = "浏览器已打开，请登录后回到本窗口点击『完成采集』"
+                status_label = getattr(self, "_mimo_status_label", None)
+                if status_label is not None:
+                    status_label.setText(button_text)
+
+            QTimer.singleShot(500, _after_poll)
+        except Exception:
+            pass
+
+    def _finish_mimo_cookie_acquire(self) -> None:
+        worker = getattr(self, "_mimo_cookie_worker", None)
+        if worker is None:
+            return
+        status_label = getattr(self, "_mimo_status_label", None)
+        if status_label is not None:
+            status_label.setText("正在读取 Cookie…")
+        worker.stop_and_collect()
+
+    def _apply_mimo_cookie_from_acquired(self, cookie_text: str) -> None:
+        if self._rendered_provider_id != "mimo":
+            return
+        normalized = _normalize_cookie(cookie_text)
+        if not normalized:
+            return
+        cookie_widget = self._provider_widgets.get("COOKIE")
+        ph_widget = self._provider_widgets.get("API_PLATFORM_PH")
+        # 1) Cookie 输入框：直接填（覆盖旧值），保持用户在浏览器里拿到的最新会话。
+        if cookie_widget is not None:
+            if isinstance(cookie_widget, QPlainTextEdit):
+                cookie_widget.setPlainText(normalized)
+            else:
+                cookie_widget.setText(normalized)
+        # 2) api-platform_ph 输入框：无论原来是否有值，都从 cookie 里解析一次
+        # 并填入，确保保存的 URL query 和请求头一致。
+        ph_value = _extract_cookie_value(normalized, "api-platform_ph")
+        if ph_widget is not None:
+            if isinstance(ph_widget, QPlainTextEdit):
+                ph_widget.setPlainText(ph_value)
+            else:
+                ph_widget.setText(ph_value)
+        # 3) 同步写入 provider_drafts，防止「用户没有再次修改输入框」时保存走旧值。
+        draft = self._provider_drafts.setdefault("mimo", {})
+        if cookie_widget is not None:
+            draft["COOKIE"] = normalized
+        if ph_widget is not None:
+            draft["API_PLATFORM_PH"] = ph_value
+        acquire_button = getattr(self, "_mimo_acquire_button", None)
+        if acquire_button is not None:
+            acquire_button.setEnabled(True)
+            acquire_button.setText("一键获取 MiMo Cookie")
+        finish_button = getattr(self, "_mimo_finish_button", None)
+        if finish_button is not None:
+            finish_button.setVisible(False)
+        status_label = getattr(self, "_mimo_status_label", None)
+        if status_label is not None:
+            status_label.setText("Cookie 已自动填入，请保存设置。")
+
+    def _mimo_acquire_failed(self, message: str) -> None:
+        acquire_button = getattr(self, "_mimo_acquire_button", None)
+        if acquire_button is not None:
+            acquire_button.setEnabled(True)
+            acquire_button.setText("重试")
+        finish_button = getattr(self, "_mimo_finish_button", None)
+        if finish_button is not None:
+            finish_button.setVisible(False)
+        status_label = getattr(self, "_mimo_status_label", None)
+        if status_label is not None:
+            status_label.setText(str(message))
+        config_manager.logger().warning("mimo cookie acquire failed: %s", str(message))
+
+    def _cleanup_mimo_cookie_worker(self) -> None:
+        worker = getattr(self, "_mimo_cookie_worker", None)
+        if worker is not None and hasattr(worker, "deleteLater"):
+            worker.deleteLater()
+        self._mimo_cookie_worker = None
+
     def _remember_visible_credentials(self) -> None:
         if not self._rendered_provider_id:
             return
@@ -329,6 +477,27 @@ class SettingsWindow(QDialog):
                             ph_widget.setPlainText(ph_in_cookie)
                         else:
                             ph_widget.setText(ph_in_cookie)
+            # 在「Cookie」输入框下方加一行：一键获取 MiMo Cookie 按钮与状态提示。
+            if provider_id == "mimo":
+                cookie_row = QWidget()
+                cookie_row_layout = QHBoxLayout(cookie_row)
+                cookie_row_layout.setContentsMargins(0, 4, 0, 0)
+                cookie_row_layout.setSpacing(8)
+                acquire_button = QPushButton("一键获取 MiMo Cookie")
+                acquire_button.setCursor(cookie_row.cursor())
+                acquire_button.clicked.connect(self._begin_mimo_cookie_acquire)
+                self._mimo_acquire_button = acquire_button
+                self._mimo_finish_button = QPushButton("完成采集")
+                self._mimo_finish_button.setVisible(False)
+                self._mimo_finish_button.clicked.connect(self._finish_mimo_cookie_acquire)
+                status_label = QLabel("通过本机浏览器登录后，可一键把 Cookie 填回到上方输入框。")
+                status_label.setWordWrap(True)
+                status_label.setStyleSheet(f"color: {C_SUBTEXT}; font-size: 12px;")
+                self._mimo_status_label = status_label
+                cookie_row_layout.addWidget(acquire_button)
+                cookie_row_layout.addWidget(self._mimo_finish_button)
+                cookie_row_layout.addWidget(status_label, 1)
+                self.credentials_layout.addWidget(cookie_row)
         self._rendered_provider_id = provider_id
         self._sync_window_size()
 

--- a/ui/qt_widget.py
+++ b/ui/qt_widget.py
@@ -236,6 +236,8 @@ class FloatingWidget(QWidget):
             self._expand_vertical = vertical
             self.clearMask()
             self.setWindowFlag(Qt.WindowType.WindowDoesNotAcceptFocus, False)
+            # 展开面板时去掉置顶标志，避免面板窗口压在其它应用上面。
+            self.setWindowFlag(Qt.WindowType.WindowStaysOnTopHint, False)
             self._arrange_expanded()
             self.panel.show()
             self.setFixedSize(width, height)
@@ -277,6 +279,8 @@ class FloatingWidget(QWidget):
             # Compact mode remains clickable but cannot take keyboard focus away
             # from the application the user is currently working in.
             self.setWindowFlag(Qt.WindowType.WindowDoesNotAcceptFocus, True)
+            # 收回悬浮球时恢复置顶标志，让悬浮球始终浮在其它窗口之上。
+            self.setWindowFlag(Qt.WindowType.WindowStaysOnTopHint, True)
             self.clearMask()
             self.show()
             self._apply_native_window_shape(compact=True)
@@ -297,14 +301,10 @@ class FloatingWidget(QWidget):
         return super().event(event)
 
     def _collapse_after_deactivation(self) -> None:
-        if (
-            self._expanded
-            and not self._transitioning
-            and not self._drag_started
-            and not self._has_settings_child()
-            and not self.isActiveWindow()
-        ):
-            self.collapse_panel()
+        # 面板展开时，用户点击其它应用是正常操作，不应自动回收面板；
+        # 只有显式的关闭按钮、ESC 或点击悬浮球才触发回收。
+        # 此方法保留为空壳，供未来需要恢复自动回收行为时使用。
+        pass
 
     def _has_settings_child(self) -> bool:
         return bool(self._settings_window and self._settings_window.isVisible())
@@ -594,6 +594,9 @@ class FloatingWidget(QWidget):
                 on_saved=self._on_config_saved,
                 update_controller=self._update_controller,
             )
+            # 设置窗口作为普通对话框，不应继承主窗口的置顶标志；
+            # 否则会和悬浮球一起把其它应用压在下面。
+            self._settings_window.setWindowFlag(Qt.WindowType.WindowStaysOnTopHint, False)
         self._settings_window.show()
         self._settings_window.raise_()
         self._settings_window.activateWindow()


### PR DESCRIPTION
- 新增 MiMo 凭据区「一键获取 Cookie」按钮，通过 CDP 协议拉起本机 Chrome/Edge，用户登录后自动读取 Cookie 并回填到输入框
- 修复 CDP 握手在 --app 模式下因响应头差异误判失败的问题（101 匹配）； 放宽 target 类型限制（page/app/background_page/other）
- 改用 Network.getAllCookies 获取全量 Cookie，避免当前页面域返回空列表
- 采集完成后用 Browser.close 优雅退出，保留登录态到 user-data-dir
- 获取后同时回填 Cookie 与 api-platform_ph 到输入框和 drafts， 保证保存生效；domain 过滤放宽、值去引号，避免 404
- 修复面板和设置窗口继承 WindowStaysOnTopHint 导致其它应用被压下面
- 修复点击其它应用时面板自动回收，现仅支持 ESC/关闭按钮/点击悬浮球