### PR TITLE
feat: add multi-provider background collection

### DIFF
--- a/api/providers/__init__.py
+++ b/api/providers/__init__.py
@@ -44,6 +44,35 @@ def list_providers() -> list[tuple[str, str]]:
     return [(provider.id, provider.name) for provider in PROVIDERS.values()]
 
 
+def configured_provider_ids(config: Mapping[str, Any] | None = None) -> list[str]:
+    """Return every configured provider ID for one captured configuration."""
+
+    captured = dict(config) if config is not None else config_manager.all_config()
+    configured: list[str] = []
+    for provider_id, provider_cls in PROVIDERS.items():
+        provider: Provider | None = None
+        try:
+            provider = provider_cls(captured)
+            if provider.is_configured():
+                configured.append(provider_id)
+        except Exception:
+            # Configuration probing must not let one adapter block the remaining
+            # providers, and the log deliberately excludes config values.
+            config_manager.logger().warning(
+                "Provider configuration probe failed: provider=%s", provider_id
+            )
+        finally:
+            if provider is not None:
+                try:
+                    provider.close()
+                except Exception:
+                    config_manager.logger().warning(
+                        "Provider configuration probe cleanup failed: provider=%s",
+                        provider_id,
+                    )
+    return configured
+
+
 def active_providers(config: Mapping[str, Any] | None = None) -> Iterator[Provider]:
     """Iterate providers matching the currently selected ``ACTIVE_PROVIDER``
     configuration key (single-provider mode), or fall back to the first
@@ -85,5 +114,6 @@ __all__ = [
     "PROVIDERS",
     "get_provider",
     "list_providers",
+    "configured_provider_ids",
     "active_providers",
 ]

--- a/data/history.py
+++ b/data/history.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+import threading
 from contextlib import closing, contextmanager
 from datetime import date, datetime, timedelta
 from decimal import Decimal, InvalidOperation
@@ -13,6 +14,7 @@ from config import runtime as config_manager
 
 DB_PATH = config_manager.CONFIG_DIR / "usage.db"
 MINUTE_USAGE_CLEANUP_GRACE_MULTIPLIER = 2
+_SCHEMA_LOCK = threading.Lock()
 
 MINUTE_TOKEN_TYPES = (
     "PROMPT_CACHE_HIT_TOKEN",
@@ -66,8 +68,10 @@ def _connect() -> Iterator[sqlite3.Connection]:
     DB_PATH.parent.mkdir(parents=True, exist_ok=True)
     connection = sqlite3.connect(DB_PATH, timeout=5)
     try:
-        connection.execute("PRAGMA journal_mode=WAL")
-        with connection:
+        # 多 Provider 首次并发访问时只串行化建表/旧结构检查；实际读写事务
+        # 仍由各自连接独立执行。
+        with _SCHEMA_LOCK, connection:
+            connection.execute("PRAGMA journal_mode=WAL")
             _ensure_daily_usage_schema(connection)
             connection.executescript(
                 """
@@ -125,6 +129,7 @@ def _connect() -> Iterator[sqlite3.Connection]:
                     ON minute_cost_snapshot(provider, usage_date);
                 """
             )
+        with connection:
             yield connection
     finally:
         # sqlite Connection 的上下文只处理事务，文件句柄仍需显式关闭。
@@ -438,7 +443,7 @@ def _save_estimated_minute_cost_usage(
     ):
         return
     delta = cost_cny - previous
-    if delta < 0:
+    if delta <= 0:
         return
     indexes = _minute_indexes(previous_at, observed_at)
     share = delta / len(indexes)
@@ -588,6 +593,12 @@ def save_estimated_minute_usage(
                                        updated_at = excluded.updated_at""",
                                 (provider, usage_date, minute, token_type, amount, updated_at),
                             )
+                    config_manager.logger().debug(
+                        "Minute delta distributed: provider=%s gap_minutes=%s token_total=%s",
+                        provider,
+                        len(minute_indexes),
+                        sum(deltas.values()),
+                    )
                     status = "recorded"
         _save_estimated_minute_cost_usage(
             connection, provider, usage_date, cost_cny, observed_at

--- a/data/store.py
+++ b/data/store.py
@@ -499,7 +499,7 @@ class TokenData:
         if getattr(provider, "supports_estimated_minute_usage", False):
             try:
                 # 每次启动/刷新均按设置的保留天数清理；失败不能影响原有账单刷新。
-                retention_days = int(config_manager.get("MINUTE_USAGE_RETENTION_DAYS", 3))
+                retention_days = int(provider.config_get("MINUTE_USAGE_RETENTION_DAYS", 3))
                 history.clear_expired_minute_usage(
                     provider.id, current_day, retention_days
                 )
@@ -624,8 +624,9 @@ class TokenData:
             if summary_error:
                 per.errors.append(summary_error)
 
-            if lightweight and provider.id == "mimo":
-                # 收起状态的 MiMo 悬浮球只需当前日金额；跳过历史补同步，避免它阻塞可见数值更新。
+            if lightweight:
+                # 轻量采集只请求当前月；非当前 Provider 的分钟采样不能每分钟
+                # 重复历史补同步，收起状态的 MiMo 继续复用同一路径。
                 request_months = [(current_day.month, current_day.year)]
             else:
                 current_month = (current_day.month, current_day.year)
@@ -810,7 +811,6 @@ class TokenData:
             data.is_stale = bool(per.errors)
             with cls._cache_lock:
                 cls._provider_snapshots[provider.id] = copy.deepcopy(data)
-                cls._last_snapshot = copy.deepcopy(data)
         else:
             data.status = "error" if per.status != "not_configured" else "not_configured"
             data.is_stale = per.is_stale

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,6 +1,7 @@
 import os
 import sqlite3
 import tempfile
+import threading
 import unittest
 from contextlib import closing
 from datetime import date, datetime, timedelta
@@ -112,6 +113,19 @@ class HistoryTests(unittest.TestCase):
                     connection.close()
                 self.assertIn("minute_usage", tables)
                 self.assertIn("minute_usage_snapshot", tables)
+                self.assertIn("minute_cost_usage", tables)
+                self.assertIn("minute_cost_snapshot", tables)
+                with closing(sqlite3.connect(db_path)) as schema_connection:
+                    self.assertEqual(
+                        [
+                            row[1]
+                            for row in schema_connection.execute(
+                                "PRAGMA table_info(minute_usage)"
+                            )
+                            if row[5]
+                        ],
+                        ["provider", "usage_date", "minute_index", "token_type"],
+                    )
 
     def test_backup_usage_database_creates_verified_pre_update_snapshot(self):
         with tempfile.TemporaryDirectory(dir=self.temp_root()) as directory:
@@ -185,6 +199,147 @@ class HistoryTests(unittest.TestCase):
                     "unchanged",
                 )
                 self.assertEqual(history.minute_usage_for_day("mimo", usage_day), rows)
+
+    def test_long_same_day_gap_distributes_all_token_and_cost_delta(self):
+        with tempfile.TemporaryDirectory(dir=self.temp_root()) as directory:
+            with patch.object(history, "DB_PATH", Path(directory) / "usage.db"):
+                usage_day = date(2026, 8, 13)
+                first = datetime(2026, 8, 13, 14, 28)
+                second = datetime(2026, 8, 13, 17, 1)
+                initial = {
+                    "PROMPT_CACHE_HIT_TOKEN": 1_000_000,
+                    "PROMPT_CACHE_MISS_TOKEN": 2_000_000,
+                    "RESPONSE_TOKEN": 3_000_000,
+                }
+                current = {
+                    "PROMPT_CACHE_HIT_TOKEN": 1_400_000,
+                    "PROMPT_CACHE_MISS_TOKEN": 2_300_000,
+                    "RESPONSE_TOKEN": 3_126_700,
+                }
+                history.save_estimated_minute_usage(
+                    "mimo", usage_day, initial, first, cost_cny=Decimal("10")
+                )
+                self.assertEqual(
+                    history.save_estimated_minute_usage(
+                        "mimo", usage_day, current, second, cost_cny=Decimal("12.53")
+                    ),
+                    "recorded",
+                )
+
+                token_rows = history.minute_usage_for_day("mimo", usage_day)
+                self.assertEqual({row["minute"] for row in token_rows}, set(range(869, 1022)))
+                self.assertEqual(sum(row["token_amount"] for row in token_rows), 826_700)
+                cost_rows = history.minute_cost_usage_for_day("mimo", usage_day)
+                self.assertEqual([row["minute"] for row in cost_rows], list(range(869, 1022)))
+                self.assertEqual(sum(row["cost_cny"] for row in cost_rows), Decimal("2.53"))
+
+    def test_same_day_recovery_keeps_persisted_baseline_and_provider_isolation(self):
+        with tempfile.TemporaryDirectory(dir=self.temp_root()) as directory:
+            db_path = Path(directory) / "usage.db"
+            usage_day = date(2026, 8, 13)
+            totals = {token_type: 0 for token_type in history.MINUTE_TOKEN_TYPES}
+            with patch.object(history, "DB_PATH", db_path):
+                history.save_estimated_minute_usage(
+                    "mimo", usage_day, totals, datetime(2026, 8, 13, 10, 0)
+                )
+                # A later call uses a fresh SQLite connection, matching restart,
+                # sleep, network recovery and authentication recovery semantics.
+                recovered = dict(totals)
+                recovered["RESPONSE_TOKEN"] = 20
+                self.assertEqual(
+                    history.save_estimated_minute_usage(
+                        "mimo", usage_day, recovered, datetime(2026, 8, 13, 10, 20)
+                    ),
+                    "recorded",
+                )
+                history.save_estimated_minute_usage(
+                    "deepseek", usage_day, totals, datetime(2026, 8, 13, 10, 0)
+                )
+                deepseek = dict(totals)
+                deepseek["RESPONSE_TOKEN"] = 7
+                history.save_estimated_minute_usage(
+                    "deepseek", usage_day, deepseek, datetime(2026, 8, 13, 10, 1)
+                )
+
+                self.assertEqual(
+                    sum(
+                        row["token_amount"]
+                        for row in history.minute_usage_for_day("mimo", usage_day)
+                    ),
+                    20,
+                )
+                self.assertEqual(
+                    sum(
+                        row["token_amount"]
+                        for row in history.minute_usage_for_day("deepseek", usage_day)
+                    ),
+                    7,
+                )
+
+    def test_concurrent_provider_first_access_initializes_shared_database_safely(self):
+        with tempfile.TemporaryDirectory(dir=self.temp_root()) as directory:
+            with patch.object(history, "DB_PATH", Path(directory) / "usage.db"):
+                usage_day = date(2026, 8, 13)
+                totals = {token_type: 0 for token_type in history.MINUTE_TOKEN_TYPES}
+                barrier = threading.Barrier(2)
+                errors = []
+
+                def save(provider):
+                    try:
+                        barrier.wait()
+                        history.save_estimated_minute_usage(
+                            provider,
+                            usage_day,
+                            totals,
+                            datetime(2026, 8, 13, 10, 0),
+                        )
+                    except Exception as exc:
+                        errors.append(exc)
+
+                threads = [
+                    threading.Thread(target=save, args=(provider,))
+                    for provider in ("deepseek", "mimo")
+                ]
+                for thread in threads:
+                    thread.start()
+                for thread in threads:
+                    thread.join()
+
+                self.assertEqual(errors, [])
+                self.assertEqual(history.minute_usage_dates("deepseek"), ["2026-08-13"])
+                self.assertEqual(history.minute_usage_dates("mimo"), ["2026-08-13"])
+
+    def test_zero_delta_cross_day_and_adjustment_only_rebuild_baseline(self):
+        with tempfile.TemporaryDirectory(dir=self.temp_root()) as directory:
+            with patch.object(history, "DB_PATH", Path(directory) / "usage.db"):
+                usage_day = date(2026, 8, 13)
+                totals = {token_type: 10 for token_type in history.MINUTE_TOKEN_TYPES}
+                first = datetime(2026, 8, 13, 10, 0)
+                self.assertEqual(
+                    history.save_estimated_minute_usage("mimo", usage_day, totals, first),
+                    "baseline",
+                )
+                self.assertEqual(
+                    history.save_estimated_minute_usage(
+                        "mimo", usage_day, totals, first + timedelta(minutes=1)
+                    ),
+                    "unchanged",
+                )
+                adjusted = dict(totals)
+                adjusted["RESPONSE_TOKEN"] = 9
+                self.assertEqual(
+                    history.save_estimated_minute_usage(
+                        "mimo", usage_day, adjusted, first + timedelta(minutes=2)
+                    ),
+                    "adjusted",
+                )
+                self.assertEqual(
+                    history.save_estimated_minute_usage(
+                        "mimo", usage_day, adjusted, first + timedelta(days=1)
+                    ),
+                    "cross_day",
+                )
+                self.assertEqual(history.minute_usage_for_day("mimo", usage_day), [])
 
     def test_minute_cleanup_keeps_daily_history_and_rolls_back_on_failure(self):
         with tempfile.TemporaryDirectory(dir=self.temp_root()) as directory:
@@ -341,8 +496,7 @@ class HistoryTests(unittest.TestCase):
                     "deepseek", usage_day, zero_totals, second, cost_cny=Decimal(".50")
                 )
                 self.assertEqual(
-                    [row["cost_cny"] for row in history.minute_cost_usage_for_day("deepseek", usage_day)],
-                    [Decimal("0"), Decimal("0"), Decimal("0")],
+                    history.minute_cost_usage_for_day("deepseek", usage_day), []
                 )
 
                 history.save_estimated_minute_usage(

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -14,6 +14,7 @@ os.environ["APPDATA"] = str(Path.cwd() / ".test-appdata")
 
 import config_manager
 from api.deepseek import APIError
+from api.providers import configured_provider_ids
 from api.providers.base import build_session
 from api.providers.codex import CodexProvider
 from api.providers.deepseek import DeepSeekProvider
@@ -29,6 +30,47 @@ def response(payload, status=200):
 
 
 class MultiProviderTests(unittest.TestCase):
+    def test_configured_provider_ids_includes_all_configured_and_closes_probes(self):
+        instances = []
+
+        class ProbeProvider:
+            def __init__(self, config):
+                self._config = config
+                self.closed = False
+                instances.append(self)
+
+            def is_configured(self):
+                return bool(self._config.get(self.id))
+
+            def close(self):
+                self.closed = True
+
+        classes = {}
+        for provider_id in ("deepseek", "mimo", "codex"):
+            classes[provider_id] = type(provider_id, (ProbeProvider,), {"id": provider_id})
+
+        config = {"deepseek": True, "mimo": False, "codex": True}
+        with patch("api.providers.PROVIDERS", classes):
+            self.assertEqual(configured_provider_ids(config), ["deepseek", "codex"])
+
+        self.assertTrue(all(instance.closed for instance in instances))
+
+    def test_configured_provider_ids_isolates_probe_failure(self):
+        good = Mock()
+        good.is_configured.return_value = True
+        failed = Mock()
+        failed.is_configured.side_effect = RuntimeError("bad config")
+        registry = {
+            "failed": Mock(return_value=failed),
+            "good": Mock(return_value=good),
+        }
+
+        with patch("api.providers.PROVIDERS", registry):
+            self.assertEqual(configured_provider_ids({}), ["good"])
+
+        failed.close.assert_called_once()
+        good.close.assert_called_once()
+
     def test_codex_home_accepts_legacy_auth_file_path(self):
         home = Path("C:/Users/example/.codex")
         provider = CodexProvider({"CODEX_HOME": str(home / "auth.json")})

--- a/tests/test_qt_ui.py
+++ b/tests/test_qt_ui.py
@@ -922,6 +922,14 @@ def test_minute_chart_handles_zero_cache_denominator_and_panel_defaults_to_annua
     assert panel.minute_estimate_label.text() == "估算"
     assert "按刷新间隔均摊" in panel.minute_estimate_label.toolTip()
     assert not panel.activity_summary.text().startswith("估算")
+    panel.resize(820, panel.height())
+    APP.processEvents()
+    assert not panel.minute_estimate_label.isHidden()
+    assert [
+        panel.minute_legend_buttons[token_type].text()
+        for token_type, _label in MinuteUsageChart.SERIES
+    ] == ["命中缓存", "未命中", "输出"]
+    assert "峰值" in panel.minute_chart.summary_text()
     assert not panel.minute_previous_button.isEnabled()
     assert not panel.minute_next_button.isEnabled()
     panel.close()

--- a/tests/test_refresh.py
+++ b/tests/test_refresh.py
@@ -11,7 +11,12 @@ from data.store import FetchError, PerProviderData, TokenData
 from deepseek_pricing import BEIJING_TIMEZONE, PricingState
 from PySide6.QtWidgets import QApplication, QSystemTrayIcon
 from ui.qt_panel import MainPanel
-from ui.qt_widget import FloatingWidget, MiMoRenewalTask
+from ui.qt_widget import (
+    BACKGROUND_PROVIDER_INTERVAL_MS,
+    FetchTask,
+    FloatingWidget,
+    MiMoRenewalTask,
+)
 
 APP = QApplication.instance() or QApplication([])
 
@@ -20,8 +25,12 @@ def widget_stub():
     widget = FloatingWidget.__new__(FloatingWidget)
     widget._refresh_lock = __import__("threading").Lock()
     widget._refreshing = False
-    widget._pending_refresh = False
     widget._request_id = 0
+    widget._in_flight_requests = {}
+    widget._pending_refreshes = {}
+    widget._provider_results = {}
+    widget._provider_last_started = {}
+    widget._provider_task_started = {}
     widget._closed = False
     widget._data = TokenData()
     widget._expanded = False
@@ -29,15 +38,24 @@ def widget_stub():
     widget._apply_update = Mock()
     widget._thread_pool = Mock()
     widget._refresh_timer = Mock()
+    widget._background_refresh_timer = Mock()
     widget.panel = Mock()
     widget.tray = Mock()
     widget.open_settings = Mock()
     widget._sync_pricing_state = Mock()
-    widget._auth_expired_notified = False
+    widget._auth_error_signatures = {}
     widget._auth_expired_provider_id = None
     widget._mimo_renewal_task = None
     widget._mimo_renewal_attempted = False
     return widget
+
+
+def finish(widget, provider_id, request_id, result, active_provider=None):
+    active = active_provider or provider_id
+    widget._in_flight_requests[provider_id] = request_id
+    widget._provider_task_started[provider_id] = __import__("time").monotonic()
+    with patch("ui.qt_widget.config_manager.get", return_value=active):
+        widget._finish_refresh(request_id, provider_id, result)
 
 
 def pricing_widget_stub():
@@ -140,26 +158,118 @@ class RefreshTests(unittest.TestCase):
         self.assertTrue(task._lightweight)
         self.assertEqual(task._config["ACTIVE_PROVIDER"], "mimo")
 
+    def test_background_cycle_starts_every_configured_non_current_provider(self):
+        widget = widget_stub()
+        config = {"ACTIVE_PROVIDER": "codex", "MARKER": "captured"}
+        with (
+            patch("ui.qt_widget.config_manager.all_config", return_value=config),
+            patch(
+                "ui.qt_widget.configured_provider_ids",
+                return_value=["deepseek", "mimo", "codex"],
+            ),
+            patch("ui.qt_widget.config_manager.get", return_value="codex"),
+        ):
+            widget._periodic_background_refresh()
+
+        self.assertEqual(widget._thread_pool.start.call_count, 2)
+        tasks = [call.args[0] for call in widget._thread_pool.start.call_args_list]
+        self.assertEqual([task.provider_id for task in tasks], ["deepseek", "mimo"])
+        self.assertTrue(all(task._lightweight for task in tasks))
+        self.assertTrue(all(task._config["MARKER"] == "captured" for task in tasks))
+
+    def test_background_cycle_does_not_start_unconfigured_provider(self):
+        widget = widget_stub()
+        with (
+            patch(
+                "ui.qt_widget.config_manager.all_config",
+                return_value={"ACTIVE_PROVIDER": "codex"},
+            ),
+            patch("ui.qt_widget.configured_provider_ids", return_value=["codex"]),
+        ):
+            widget._periodic_background_refresh()
+
+        widget._thread_pool.start.assert_not_called()
+
+    def test_provider_level_in_flight_does_not_block_other_provider(self):
+        widget = widget_stub()
+        with patch("ui.qt_widget.config_manager.get", return_value="codex"):
+            self.assertTrue(
+                widget._start_provider_refresh(
+                    "deepseek",
+                    {"ACTIVE_PROVIDER": "codex"},
+                    lightweight=True,
+                    queue_if_busy=False,
+                    reason="test",
+                )
+            )
+            self.assertFalse(
+                widget._start_provider_refresh(
+                    "deepseek",
+                    {"ACTIVE_PROVIDER": "codex"},
+                    lightweight=True,
+                    queue_if_busy=False,
+                    reason="test",
+                )
+            )
+            self.assertTrue(
+                widget._start_provider_refresh(
+                    "mimo",
+                    {"ACTIVE_PROVIDER": "codex"},
+                    lightweight=True,
+                    queue_if_busy=False,
+                    reason="test",
+                )
+            )
+
+        self.assertEqual(widget._thread_pool.start.call_count, 2)
+        self.assertEqual(set(widget._in_flight_requests), {"deepseek", "mimo"})
+
+    def test_background_provider_never_runs_faster_than_sixty_seconds(self):
+        widget = widget_stub()
+        widget._provider_last_started["mimo"] = __import__("time").monotonic()
+        with (
+            patch(
+                "ui.qt_widget.config_manager.all_config",
+                return_value={"ACTIVE_PROVIDER": "codex"},
+            ),
+            patch("ui.qt_widget.configured_provider_ids", return_value=["mimo", "codex"]),
+        ):
+            widget._periodic_background_refresh()
+
+        self.assertEqual(BACKGROUND_PROVIDER_INTERVAL_MS, 60_000)
+        widget._thread_pool.start.assert_not_called()
+
+    def test_fetch_task_owns_independent_config_snapshot(self):
+        config = {"ACTIVE_PROVIDER": "mimo", "MIMO_COOKIE": "original"}
+        task = FetchTask(1, config, lightweight=True)
+        config["ACTIVE_PROVIDER"] = "codex"
+        config["MIMO_COOKIE"] = "changed"
+
+        self.assertEqual(task.provider_id, "mimo")
+        self.assertEqual(task._config["MIMO_COOKIE"], "original")
+
     def test_repeated_refresh_runs_once_then_one_pending(self):
         widget = widget_stub()
-        widget.refresh()
-        widget.refresh()
-        widget.refresh()
+        with patch("ui.qt_widget.config_manager.get", return_value="deepseek"):
+            widget.refresh()
+            widget.refresh()
+            widget.refresh()
         self.assertEqual(widget._thread_pool.start.call_count, 1)
-        self.assertTrue(widget._pending_refresh)
+        self.assertIn("deepseek", widget._pending_refreshes)
 
     def test_provider_switch_starts_without_waiting_for_previous_refresh(self):
         widget = widget_stub()
-        widget._refreshing = True
-        widget._pending_refresh = True
         widget._request_id = 4
+        widget._in_flight_requests["deepseek"] = 4
+        widget._provider_task_started["deepseek"] = __import__("time").monotonic()
         loading = TokenData(
             per_provider=[PerProviderData("codex", "Codex")],
             status="loading",
         )
         snapshot = {"ACTIVE_PROVIDER": "codex", "CODEX_HOME": ""}
 
-        widget._prepare_scope_switch(loading, snapshot)
+        with patch("ui.qt_widget.config_manager.get", return_value="codex"):
+            widget._prepare_scope_switch(loading, snapshot)
 
         self.assertEqual(widget._thread_pool.start.call_count, 1)
         task = widget._thread_pool.start.call_args.args[0]
@@ -167,18 +277,24 @@ class RefreshTests(unittest.TestCase):
         self.assertEqual(task._config, snapshot)
         self.assertIs(widget._data, loading)
         self.assertTrue(widget._refreshing)
-        self.assertFalse(widget._pending_refresh)
 
-        widget._finish_refresh(4, TokenData(today_tokens=1))
+        finish(
+            widget,
+            "deepseek",
+            4,
+            TokenData(today_tokens=1),
+            active_provider="codex",
+        )
         self.assertIs(widget._data, loading)
         self.assertTrue(widget._refreshing)
+        self.assertEqual(widget._provider_results["deepseek"].today_tokens, 1)
 
         current = TokenData(
             per_provider=[PerProviderData("codex", "Codex")],
             today_tokens=2,
             status="ok",
         )
-        widget._finish_refresh(5, current)
+        finish(widget, "codex", 5, current)
         self.assertIs(widget._data, current)
         self.assertFalse(widget._refreshing)
 
@@ -193,7 +309,7 @@ class RefreshTests(unittest.TestCase):
         snapshot = {"ACTIVE_PROVIDER": "codex", "CODEX_HOME": ""}
 
         with (
-            patch("ui.qt_widget.config_manager.get", return_value="deepseek"),
+            patch("ui.qt_widget.config_manager.get", side_effect=["deepseek", "codex"]),
             patch("ui.qt_widget.config_manager.save_config", return_value=snapshot),
             patch.object(TokenData, "cached_snapshot", return_value=cached),
         ):
@@ -204,25 +320,64 @@ class RefreshTests(unittest.TestCase):
         self.assertTrue(widget._refreshing)
         self.assertEqual(widget._thread_pool.start.call_count, 1)
 
-    def test_older_request_does_not_replace_newer_data(self):
+    def test_non_current_provider_result_does_not_replace_current_data(self):
         widget = widget_stub()
         current = TokenData(balance_cny=2)
         widget._data = current
         widget._refreshing = True
-        widget._request_id = 2
-        widget._finish_refresh(1, TokenData(balance_cny=1))
+        finish(
+            widget,
+            "deepseek",
+            1,
+            TokenData(balance_cny=1),
+            active_provider="codex",
+        )
         self.assertIs(widget._data, current)
         self.assertTrue(widget._refreshing)
+        self.assertEqual(widget._provider_results["deepseek"].balance_cny, 1)
+
+    def test_current_provider_result_updates_interface(self):
+        widget = widget_stub()
+        result = TokenData(
+            per_provider=[PerProviderData("codex", "Codex")],
+            balance_cny=3,
+            status="ok",
+        )
+
+        finish(widget, "codex", 1, result)
+
+        self.assertIs(widget._data, result)
+        self.assertFalse(widget._refreshing)
+        widget._apply_update.assert_called_once()
+
+    def test_provider_failure_does_not_block_other_provider_completion(self):
+        widget = widget_stub()
+        failed = TokenData(
+            per_provider=[PerProviderData("mimo", "小米 MiMo")],
+            status="error",
+            errors=[FetchError("NETWORK_ERROR", "明细", "连接失败")],
+        )
+        success = TokenData(
+            per_provider=[PerProviderData("codex", "Codex")],
+            today_tokens=8,
+            status="ok",
+        )
+
+        finish(widget, "mimo", 1, failed, active_provider="codex")
+        finish(widget, "codex", 2, success)
+
+        self.assertEqual(widget._provider_results["mimo"].status, "error")
+        self.assertIs(widget._data, success)
+        self.assertEqual(widget._data.today_tokens, 8)
 
     def test_auth_expired_shows_one_tray_notification_until_recovery(self):
         widget = widget_stub()
-        widget._request_id = 1
         expired = TokenData(
             errors=[FetchError("AUTH_EXPIRED", "余额", "Cookie 已失效")]
         )
 
-        widget._finish_refresh(1, expired)
-        widget._finish_refresh(1, expired)
+        widget._notify_auth_expired(expired, "deepseek", is_current=True)
+        widget._notify_auth_expired(expired, "deepseek", is_current=True)
 
         self.assertEqual(widget.tray.showMessage.call_count, 1)
         title, message, icon, timeout = widget.tray.showMessage.call_args.args
@@ -232,23 +387,35 @@ class RefreshTests(unittest.TestCase):
         self.assertEqual(icon, QSystemTrayIcon.MessageIcon.Warning)
         self.assertEqual(timeout, 10_000)
 
-        widget._finish_refresh(1, TokenData())
-        widget._finish_refresh(1, expired)
+        widget._notify_auth_expired(TokenData(status="ok"), "deepseek", is_current=True)
+        widget._notify_auth_expired(expired, "deepseek", is_current=True)
         self.assertEqual(widget.tray.showMessage.call_count, 2)
 
     def test_mimo_auth_expired_starts_silent_renewal(self):
         widget = widget_stub()
-        widget._request_id = 1
         expired = TokenData(
             errors=[FetchError("AUTH_EXPIRED", "MiMo 余额", "Cookie 已失效")],
             per_provider=[PerProviderData("mimo", "小米 MiMo")],
         )
 
-        widget._finish_refresh(1, expired)
+        widget._notify_auth_expired(expired, "mimo", is_current=True)
         task = widget._thread_pool.start.call_args.args[0]
         self.assertIsInstance(task, MiMoRenewalTask)
         self.assertTrue(widget._mimo_renewal_attempted)
         widget.tray.showMessage.assert_not_called()
+
+    def test_non_current_mimo_auth_expired_only_notifies_without_browser_task(self):
+        widget = widget_stub()
+        expired = TokenData(
+            errors=[FetchError("AUTH_EXPIRED", "MiMo 余额", "Cookie 已失效")],
+            per_provider=[PerProviderData("mimo", "小米 MiMo")],
+        )
+
+        widget._notify_auth_expired(expired, "mimo", is_current=False)
+
+        widget._thread_pool.start.assert_not_called()
+        widget.tray.showMessage.assert_called_once()
+        self.assertIn("不会自动打开浏览器", widget.tray.showMessage.call_args.args[1])
 
     @patch("ui.qt_widget.config_manager.save_config")
     def test_successful_mimo_renewal_saves_only_cookie_credentials(self, save_config):
@@ -256,7 +423,7 @@ class RefreshTests(unittest.TestCase):
         widget._mimo_renewal_task = Mock()
         widget._mimo_renewal_attempted = True
         widget._settings_window = Mock()
-        widget.refresh = Mock()
+        widget._refresh_mimo_after_renewal = Mock()
 
         with patch("ui.qt_widget.MiMoProvider.is_direct_cookie_usable", return_value=True):
             widget._finish_mimo_cookie_renewal(
@@ -274,7 +441,8 @@ class RefreshTests(unittest.TestCase):
             "mimo",
             "api-platform_ph=ph; api-platform_serviceToken=token; api-platform_slh=slh; userId=1",
         )
-        widget.refresh.assert_called_once_with()
+        widget._refresh_mimo_after_renewal.assert_called_once_with()
+        self.assertNotIn("mimo", widget._auth_error_signatures)
         self.assertIsNone(widget._mimo_renewal_task)
 
     @patch("ui.qt_widget.config_manager.save_config", side_effect=OSError("failed"))
@@ -289,7 +457,7 @@ class RefreshTests(unittest.TestCase):
             )
 
         self.assertEqual(widget._auth_expired_provider_id, "mimo")
-        self.assertTrue(widget._auth_expired_notified)
+        self.assertIn("mimo", widget._auth_error_signatures)
         self.assertEqual(widget.tray.showMessage.call_count, 1)
 
     @patch("ui.qt_widget.MiMoProvider.recover_verified_cookie_via_chrome")
@@ -299,7 +467,10 @@ class RefreshTests(unittest.TestCase):
         finished = Mock()
         task.signals.finished.connect(finished)
 
-        with patch("ui.qt_widget.MiMoProvider.is_direct_cookie_usable", return_value=True):
+        with (
+            patch("ui.qt_widget.config_manager.get", return_value="mimo"),
+            patch("ui.qt_widget.MiMoProvider.is_direct_cookie_usable", return_value=True),
+        ):
             task.run()
 
         self.assertEqual(recover_cookie.call_count, 2)
@@ -307,11 +478,27 @@ class RefreshTests(unittest.TestCase):
         self.assertFalse(recover_cookie.call_args_list[1].kwargs["headless"])
         finished.assert_called_once_with("fresh-cookie", "")
 
+    @patch("ui.qt_widget.MiMoProvider.recover_verified_cookie_via_chrome")
+    def test_mimo_renewal_does_not_open_visible_browser_after_provider_switch(
+        self, recover_cookie
+    ):
+        recover_cookie.side_effect = RuntimeError("MIMO_COOKIE_EMPTY")
+        task = MiMoRenewalTask()
+        finished = Mock()
+        task.signals.finished.connect(finished)
+
+        with patch("ui.qt_widget.config_manager.get", return_value="codex"):
+            task.run()
+
+        recover_cookie.assert_called_once()
+        self.assertTrue(recover_cookie.call_args.kwargs["headless"])
+        finished.assert_called_once_with("", "MIMO_COOKIE_EMPTY")
+
     @patch("ui.qt_widget.config_manager.save_config")
     def test_browser_only_renewal_does_not_overwrite_cookie_credentials(self, save_config):
         widget = widget_stub()
         widget._mimo_renewal_task = Mock()
-        widget.refresh = Mock()
+        widget._refresh_mimo_after_renewal = Mock()
 
         widget._finish_mimo_cookie_renewal(
             "session=browser-only",
@@ -319,8 +506,8 @@ class RefreshTests(unittest.TestCase):
         )
 
         save_config.assert_not_called()
-        widget.refresh.assert_called_once_with()
-        self.assertFalse(widget._auth_expired_notified)
+        widget._refresh_mimo_after_renewal.assert_called_once_with()
+        self.assertNotIn("mimo", widget._auth_error_signatures)
 
     def test_status_summary_distinguishes_configuration_and_request_errors(self):
         cases = (

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -54,11 +54,15 @@ class FakeProvider:
     supports_daily_usage = True
     supports_cost = True
 
-    def __init__(self, *, payloads=None, errors=None, configured=True):
+    def __init__(self, *, payloads=None, errors=None, configured=True, config=None):
         self.payloads = payloads or []
         self.errors = errors or []
         self.configured = configured
+        self.config = config or {}
         self.requested_months = []
+
+    def config_get(self, key, default=None):
+        return self.config.get(key, default)
 
     def is_configured(self):
         return self.configured
@@ -341,6 +345,18 @@ class StoreTests(unittest.TestCase):
         self.assertEqual(data.today_tokens, 30)
         self.assertAlmostEqual(data.today_cost_cny, .23)
 
+    def test_lightweight_background_fetch_skips_history_sync_for_other_provider(self):
+        provider = FakeProvider(payloads=[payload("2026-07-03", 30, ".23")])
+
+        with patch(
+            "data.store.history.unsynced_months", return_value=[(6, 2026)]
+        ) as unsynced_months:
+            data = self.fetch_with(provider, lightweight=True)
+
+        self.assertEqual(provider.requested_months, [[(7, 2026)]])
+        unsynced_months.assert_not_called()
+        self.assertEqual(data.today_tokens, 30)
+
     def test_complete_previous_month_uses_cache_without_refetch(self):
         provider = FakeProvider(payloads=[payload("2026-07-01", 20, ".2")])
         cached = payload("2026-06-30", 10, ".1")
@@ -463,6 +479,23 @@ class StoreTests(unittest.TestCase):
         self.assertEqual(data.minute_usage_status, "baseline")
         self.assertEqual(data.status, "partial")
         self.assertIn("LOCAL_STORAGE", {error.code for error in data.errors})
+
+    def test_minute_retention_uses_captured_provider_config(self):
+        provider = FakeProvider(
+            payloads=[payload("2026-07-03", 7, ".2")],
+            config={"MINUTE_USAGE_RETENTION_DAYS": 11},
+        )
+        provider.supports_estimated_minute_usage = True
+        with (
+            patch("data.store.history.clear_expired_minute_usage") as clear_expired,
+            patch("data.store.history.minute_usage_for_day", return_value=[]),
+            patch("data.store.history.minute_cost_usage_for_day", return_value=[]),
+            patch("data.store.history.minute_usage_dates", return_value=[]),
+            patch("data.store.history.save_estimated_minute_usage", return_value="baseline"),
+        ):
+            self.fetch_with(provider)
+
+        clear_expired.assert_called_once_with("deepseek", date(2026, 7, 3), 11)
 
     def test_minute_cost_aggregation_failure_keeps_token_sampling(self):
         provider = FakeProvider(payloads=[payload("2026-07-03", 7, ".2")])

--- a/ui/qt_panel.py
+++ b/ui/qt_panel.py
@@ -2581,7 +2581,7 @@ class MainPanel(QFrame):
     def _update_activity_header_visibility(self) -> None:
         minute_view = self._activity_view == "minute"
         self.activity_summary.setVisible(not minute_view or self.width() >= 775)
-        self.minute_estimate_label.setVisible(minute_view and self.width() < 775)
+        self.minute_estimate_label.setVisible(minute_view)
 
     def _refresh_minute_control_colors(self) -> None:
         if not hasattr(self, "minute_chart"):

--- a/ui/qt_widget.py
+++ b/ui/qt_widget.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import copy
 import ctypes
 import sys
 import threading
+import time
 from ctypes import wintypes
 from datetime import datetime
 
@@ -25,7 +27,7 @@ from PySide6.QtGui import QAction, QColor, QCursor, QGuiApplication, QPalette, Q
 from PySide6.QtWidgets import QApplication, QHBoxLayout, QMenu, QSystemTrayIcon, QWidget
 
 from config import runtime as config_manager
-from api.providers import PROVIDERS
+from api.providers import PROVIDERS, configured_provider_ids
 from api.providers.base import FetchError
 from api.providers.mimo import MiMoProvider
 from core.identity import APP_DISPLAY_NAME
@@ -51,10 +53,11 @@ MIN_BALL_SIZE = 72
 MAX_BALL_SIZE = 124
 EDGE_HIDDEN_OPACITY = 0.72
 EDGE_OPACITY_DELAY_MS = 3_000
+BACKGROUND_PROVIDER_INTERVAL_MS = 60_000
 
 
 class FetchSignals(QObject):
-    finished = Signal(int, object)
+    finished = Signal(int, str, object)
 
 
 class FetchTask(QRunnable):
@@ -67,13 +70,14 @@ class FetchTask(QRunnable):
         super().__init__()
         self.request_id = request_id
         self._config = dict(config)
+        self.provider_id = str(self._config.get("ACTIVE_PROVIDER", "")).strip().lower()
         self._lightweight = lightweight
         self.signals = FetchSignals()
 
     @Slot()
     def run(self) -> None:
         result = _fetch_tokens_safely(self._config, self._lightweight)
-        self.signals.finished.emit(self.request_id, result)
+        self.signals.finished.emit(self.request_id, self.provider_id, result)
 
 
 class MiMoRenewalSignals(QObject):
@@ -107,7 +111,14 @@ class MiMoRenewalTask(QRunnable):
             )
         except RuntimeError as exc:
             code = str(exc)
-            if self._stop_event.is_set() or code in self._NO_VISIBLE_RETRY:
+            current_provider = str(
+                config_manager.get("ACTIVE_PROVIDER", "")
+            ).strip().lower()
+            if (
+                self._stop_event.is_set()
+                or code in self._NO_VISIBLE_RETRY
+                or current_provider != "mimo"
+            ):
                 self.signals.finished.emit("", code)
                 return
             try:
@@ -173,10 +184,16 @@ class FloatingWidget(QWidget):
         self._data = TokenData()
         self._refresh_lock = threading.Lock()
         self._refreshing = False
-        self._pending_refresh = False
         self._request_id = 0
+        self._in_flight_requests: dict[str, int] = {}
+        self._pending_refreshes: dict[
+            str, tuple[dict[str, object], bool, str]
+        ] = {}
+        self._provider_results: dict[str, TokenData] = {}
+        self._provider_last_started: dict[str, float] = {}
+        self._provider_task_started: dict[str, float] = {}
         self._closed = False
-        self._auth_expired_notified = False
+        self._auth_error_signatures: dict[str, tuple[str, str, str]] = {}
         self._auth_expired_provider_id: str | None = None
         self._mimo_renewal_task: MiMoRenewalTask | None = None
         self._mimo_renewal_attempted = False
@@ -247,6 +264,9 @@ class FloatingWidget(QWidget):
 
         self._refresh_timer = QTimer(self)
         self._refresh_timer.timeout.connect(self._periodic_refresh)
+        self._background_refresh_timer = QTimer(self)
+        self._background_refresh_timer.timeout.connect(self._periodic_background_refresh)
+        self._background_refresh_timer.start(BACKGROUND_PROVIDER_INTERVAL_MS)
         self._pricing_state: PricingState | None = None
         self._pricing_timer = QTimer(self)
         self._pricing_timer.setSingleShot(True)
@@ -256,6 +276,7 @@ class FloatingWidget(QWidget):
         self._sync_pricing_state(notify_transition=False)
         self._show_compact_at_saved_position()
         self._update_controller.schedule_startup_check()
+        self._reschedule_refresh()
         self.refresh()
 
     def _connect_ui(self) -> None:
@@ -864,7 +885,11 @@ class FloatingWidget(QWidget):
             return
         self._sync_pricing_state(notify_transition=False)
         provider_cls = PROVIDERS[provider_id]
-        cached = TokenData.cached_snapshot(provider_id)
+        cached = self._provider_results.get(provider_id)
+        if cached is not None:
+            cached = copy.deepcopy(cached)
+        else:
+            cached = TokenData.cached_snapshot(provider_id)
         self._prepare_scope_switch(
             cached
             or TokenData(
@@ -886,9 +911,7 @@ class FloatingWidget(QWidget):
         self, data: TokenData, config_snapshot: dict[str, object]
     ) -> None:
         self._data = data
-        # A provider switch is allowed to supersede an in-flight refresh. The
-        # older worker can finish in the background, but its request id prevents
-        # it from changing either the data or the new loading state.
+        # 旧 Provider 继续后台完成；回调按最新 ACTIVE_PROVIDER 决定是否更新界面。
         self.refresh(force=True, config_snapshot=config_snapshot)
 
     def refresh(
@@ -896,6 +919,8 @@ class FloatingWidget(QWidget):
         *,
         force: bool = False,
         config_snapshot: dict[str, object] | None = None,
+        queue_if_busy: bool = True,
+        reason: str = "manual",
     ) -> None:
         captured_config = dict(
             config_snapshot
@@ -903,64 +928,162 @@ class FloatingWidget(QWidget):
             else config_manager.all_config()
         )
         provider_id = str(captured_config.get("ACTIVE_PROVIDER", "")).strip().lower()
-        with self._refresh_lock:
-            if self._closed:
-                return
-            if self._refreshing and not force:
-                self._pending_refresh = True
-                return
-            if force:
-                # Pending work belongs to the provider scope being replaced.
-                self._pending_refresh = False
-            self._refreshing = True
-            self._request_id += 1
-            request_id = self._request_id
-        self._apply_update()
-        task = FetchTask(
-            request_id,
+        self._start_provider_refresh(
+            provider_id,
             captured_config,
             lightweight=self._uses_lightweight_mimo_refresh(provider_id),
+            queue_if_busy=queue_if_busy and not force,
+            reason="switch" if force else reason,
         )
+
+    def _start_provider_refresh(
+        self,
+        provider_id: str,
+        config_snapshot: dict[str, object],
+        *,
+        lightweight: bool,
+        queue_if_busy: bool,
+        reason: str,
+    ) -> bool:
+        provider_id = provider_id.strip().lower()
+        if not provider_id:
+            return False
+        captured_config = dict(config_snapshot)
+        captured_config["ACTIVE_PROVIDER"] = provider_id
+        is_current = provider_id == str(
+            config_manager.get("ACTIVE_PROVIDER", "")
+        ).strip().lower()
+        with self._refresh_lock:
+            if self._closed:
+                return False
+            if provider_id in self._in_flight_requests:
+                if queue_if_busy:
+                    # 同一 Provider 只保留一个逻辑待刷新，不重复创建 QRunnable。
+                    self._pending_refreshes[provider_id] = (
+                        captured_config,
+                        lightweight,
+                        reason,
+                    )
+                if is_current:
+                    self._refreshing = True
+                request_id = self._in_flight_requests[provider_id]
+                started = False
+            else:
+                self._request_id += 1
+                request_id = self._request_id
+                self._in_flight_requests[provider_id] = request_id
+                started_at = time.monotonic()
+                self._provider_last_started[provider_id] = started_at
+                self._provider_task_started[provider_id] = started_at
+                if is_current:
+                    self._refreshing = True
+                started = True
+        if is_current:
+            self._apply_update()
+        if not started:
+            config_manager.logger().debug(
+                "Provider collection skipped: provider=%s reason=in_flight request_id=%s",
+                provider_id,
+                request_id,
+            )
+            return False
+        config_manager.logger().debug(
+            "Provider collection started: provider=%s reason=%s",
+            provider_id,
+            reason,
+        )
+        task = FetchTask(request_id, captured_config, lightweight=lightweight)
         task.signals.finished.connect(self._finish_refresh)
         self._thread_pool.start(task)
+        return True
 
-    @Slot(int, object)
-    def _finish_refresh(self, request_id: int, result: TokenData) -> None:
-        has_current_result = False
+    def _schedule_pending_refresh(
+        self,
+        provider_id: str,
+        pending: tuple[dict[str, object], bool, str],
+    ) -> None:
+        captured_config, lightweight, reason = pending
+        self._start_provider_refresh(
+            provider_id,
+            captured_config,
+            lightweight=lightweight,
+            queue_if_busy=False,
+            reason=reason,
+        )
+
+    @Slot(int, str, object)
+    def _finish_refresh(
+        self, request_id: int, provider_id: str, result: TokenData
+    ) -> None:
+        pending: tuple[dict[str, object], bool, str] | None = None
+        started_at: float | None = None
+        is_current = False
+        provider_id = provider_id.strip().lower()
         with self._refresh_lock:
             if self._closed:
                 return
-            if request_id != self._request_id:
+            if self._in_flight_requests.get(provider_id) != request_id:
                 return
-            self._data = result
-            has_current_result = True
-            self._refreshing = False
-            pending = self._pending_refresh
-            self._pending_refresh = False
-        if has_current_result:
-            self._notify_auth_expired(result)
-        self._apply_update()
-        if pending:
-            QTimer.singleShot(0, self.refresh)
+            self._in_flight_requests.pop(provider_id, None)
+            started_at = self._provider_task_started.pop(provider_id, None)
+            pending = self._pending_refreshes.pop(provider_id, None)
+            self._provider_results[provider_id] = copy.deepcopy(result)
+            is_current = provider_id == str(
+                config_manager.get("ACTIVE_PROVIDER", "")
+            ).strip().lower()
+            if is_current:
+                self._data = result
+                self._refreshing = False
+        elapsed_ms = (
+            max(0, int((time.monotonic() - started_at) * 1000))
+            if started_at is not None
+            else 0
+        )
+        config_manager.logger().debug(
+            "Provider collection completed: provider=%s status=%s elapsed_ms=%s",
+            provider_id,
+            result.status,
+            elapsed_ms,
+        )
+        self._notify_auth_expired(result, provider_id, is_current=is_current)
+        if is_current:
+            self._apply_update()
+        if pending is not None:
+            QTimer.singleShot(
+                0,
+                lambda value=pending, current_id=provider_id: self._schedule_pending_refresh(
+                    current_id, value
+                ),
+            )
 
-    def _notify_auth_expired(self, result: TokenData) -> None:
+    def _notify_auth_expired(
+        self, result: TokenData, provider_id: str, *, is_current: bool
+    ) -> None:
         auth_error = next(
             (error for error in result.errors if error.code == "AUTH_EXPIRED"), None
         )
         if auth_error is None:
-            # 只在鉴权错误解除后恢复通知资格，避免定时刷新重复弹窗。
-            self._auth_expired_notified = False
-            self._auth_expired_provider_id = None
-            self._mimo_renewal_attempted = False
+            remote_failures = {
+                "NETWORK_ERROR",
+                "NETWORK_TIMEOUT",
+                "SERVER_ERROR",
+                "RATE_LIMITED",
+                "UNKNOWN_ERROR",
+            }
+            codes = {error.code for error in result.errors}
+            if result.status in {"ok", "partial"} and not codes & remote_failures:
+                # 只有该 Provider 实际恢复成功后才重新开放相同鉴权通知。
+                self._auth_error_signatures.pop(provider_id, None)
+                if self._auth_expired_provider_id == provider_id:
+                    self._auth_expired_provider_id = None
+                if provider_id == "mimo":
+                    self._mimo_renewal_attempted = False
             return
-        provider_id = (
-            result.per_provider[0].provider_id
-            if result.per_provider
-            else str(config_manager.get("ACTIVE_PROVIDER", ""))
-        )
-        if provider_id == "mimo":
-            if getattr(self, "_auth_expired_notified", False):
-                return
+        signature = (auth_error.code, auth_error.source, auth_error.message)
+        if self._auth_error_signatures.get(provider_id) == signature:
+            return
+        self._auth_error_signatures[provider_id] = signature
+        if provider_id == "mimo" and is_current:
             if getattr(self, "_mimo_renewal_task", None) is not None:
                 return
             if getattr(self, "_mimo_renewal_attempted", False):
@@ -968,18 +1091,24 @@ class FloatingWidget(QWidget):
                 return
             self._start_mimo_cookie_renewal()
             return
-        if getattr(self, "_auth_expired_notified", False):
-            return
-        self._auth_expired_notified = True
+
         self._auth_expired_provider_id = provider_id
         tray = getattr(self, "tray", None)
-        if tray is not None:
-            tray.showMessage(
-                f"{APP_DISPLAY_NAME}：登录凭据已失效",
-                f"{auth_error.message}\n点击此通知即可重新获取 Cookie。",
-                QSystemTrayIcon.MessageIcon.Warning,
-                10_000,
+        if tray is None:
+            return
+        if provider_id == "mimo":
+            message = (
+                f"{auth_error.message}\n请切换到小米 MiMo 或打开设置重新登录；"
+                "后台不会自动打开浏览器窗口。"
             )
+        else:
+            message = f"{auth_error.message}\n点击此通知可打开对应平台设置。"
+        tray.showMessage(
+            f"{APP_DISPLAY_NAME}：登录凭据已失效",
+            message,
+            QSystemTrayIcon.MessageIcon.Warning,
+            10_000,
+        )
 
     def _start_mimo_cookie_renewal(self) -> None:
         if self._closed or getattr(self, "_mimo_renewal_task", None) is not None:
@@ -1011,17 +1140,17 @@ class FloatingWidget(QWidget):
                 settings_window = getattr(self, "_settings_window", None)
                 if settings_window is not None:
                     settings_window.sync_persisted_cookie("mimo", cookie_text)
-                self._auth_expired_notified = False
-                self._auth_expired_provider_id = None
-                self.refresh()
+                if self._auth_expired_provider_id == "mimo":
+                    self._auth_expired_provider_id = None
+                self._refresh_mimo_after_renewal()
                 return
 
         if cookie_text and error_code == "BROWSER_CONTEXT_ONLY":
             # The browser session itself was verified, but its authentication
             # cannot be safely replayed by requests. Keep existing stored
             # credentials unchanged; normal refresh will use browser fallback.
-            self._auth_expired_notified = False
-            self._auth_expired_provider_id = None
+            if self._auth_expired_provider_id == "mimo":
+                self._auth_expired_provider_id = None
             tray = getattr(self, "tray", None)
             if tray is not None:
                 tray.showMessage(
@@ -1030,14 +1159,16 @@ class FloatingWidget(QWidget):
                     QSystemTrayIcon.MessageIcon.Information,
                     10_000,
                 )
-            self.refresh()
+            self._refresh_mimo_after_renewal()
             return
 
         self._show_mimo_renewal_failure(error_code)
 
     def _show_mimo_renewal_failure(self, error_code: str) -> None:
-        self._auth_expired_notified = True
         self._auth_expired_provider_id = "mimo"
+        self._auth_error_signatures.setdefault(
+            "mimo", ("AUTH_EXPIRED", "MiMo", "authentication expired")
+        )
         message = MiMoProvider.describe_acquire_error(
             RuntimeError(error_code or "ACQUIRE_UNEXPECTED")
         )
@@ -1049,6 +1180,22 @@ class FloatingWidget(QWidget):
                 QSystemTrayIcon.MessageIcon.Warning,
                 10_000,
             )
+
+    def _refresh_mimo_after_renewal(self) -> None:
+        captured_config = config_manager.all_config()
+        active_provider = str(
+            captured_config.get("ACTIVE_PROVIDER", "")
+        ).strip().lower()
+        self._start_provider_refresh(
+            "mimo",
+            captured_config,
+            lightweight=(
+                active_provider != "mimo"
+                or self._uses_lightweight_mimo_refresh("mimo")
+            ),
+            queue_if_busy=True,
+            reason="auth_recovery",
+        )
 
     def handle_auth_expired_notification_click(self) -> None:
         provider_id = getattr(self, "_auth_expired_provider_id", None)
@@ -1090,8 +1237,33 @@ class FloatingWidget(QWidget):
             self.panel.update_data(self._data, loading, self._refreshing)
 
     def _periodic_refresh(self) -> None:
-        self.refresh()
+        self.refresh(queue_if_busy=False, reason="periodic_current")
         self._reschedule_refresh()
+
+    def _periodic_background_refresh(self) -> None:
+        if self._closed:
+            return
+        captured_config = config_manager.all_config()
+        active_provider = str(
+            captured_config.get("ACTIVE_PROVIDER", "")
+        ).strip().lower()
+        now = time.monotonic()
+        for provider_id in configured_provider_ids(captured_config):
+            if provider_id == active_provider:
+                continue
+            last_started = self._provider_last_started.get(provider_id)
+            if (
+                last_started is not None
+                and (now - last_started) * 1000 < BACKGROUND_PROVIDER_INTERVAL_MS
+            ):
+                continue
+            self._start_provider_refresh(
+                provider_id,
+                captured_config,
+                lightweight=True,
+                queue_if_busy=False,
+                reason="periodic_background",
+            )
 
     def _on_pricing_boundary(self) -> None:
         self._sync_pricing_state(notify_transition=True)
@@ -1186,6 +1358,7 @@ class FloatingWidget(QWidget):
         config_manager.save_widget_position(x, y)
         self._closed = True
         self._refresh_timer.stop()
+        self._background_refresh_timer.stop()
         self._pricing_timer.stop()
         self._edge_animation.stop()
         self._edge_hide_timer.stop()


### PR DESCRIPTION
Implements multi-provider background collection with provider-level scheduling, in-flight deduplication, configuration snapshots, result isolation, auth notification isolation, and unchanged minute-allocation structures. Validation: 314 passed, 9 subtests passed; compileall, Ruff, Pyright, and git diff --check passed. Version unchanged; no tag or release.