### PR TITLE
fix: 修复 Codex 统计同步与缓存回退

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   <sub>Codex Subscription Quota, DeepSeek & MiMo Token Usage Monitor.</sub>
 </p>
 
-TokenMeter 是一款轻量级 Windows 桌面 AI 用量监控工具。它以类似 [CodexBar](https://github.com/steipete/CodexBar) 的方式显示 Codex 订阅额度、剩余比例与重置倒计时，并从本机 Codex 会话记录生成年度 Token 活动和连续使用统计；DeepSeek 与 Xiaomi MiMo 继续展示 Token、费用、余额和历史趋势。
+TokenMeter 是一款轻量级 Windows 桌面 AI 用量监控工具。它以类似 [CodexBar](https://github.com/steipete/CodexBar) 的方式显示 Codex 订阅额度、剩余比例、重置倒计时和账号 Token 活动；DeepSeek 与 Xiaomi MiMo 继续展示 Token、费用、余额和历史趋势。
 
 ## 功能
 
@@ -35,9 +35,10 @@ TokenMeter 是一款轻量级 Windows 桌面 AI 用量监控工具。它以类�
 - 悬浮球和系统托盘常驻；Codex 以深浅主题水球显示周额度水位、剩余百分比和重置倒计时，DeepSeek/MiMo 保留金额视图。
 - 提供浅色、深色及跟随 Windows 的主题。
 - Codex 按接口返回的窗口时长展示当前周额度与重置时间，并显示订阅套餐和到期日期，不在面板展示账户邮箱；右侧显示近 7 天 Token 使用量，同时保留年度活动、累计/峰值 Token、按单个任务计算的最长聊天和连续使用天数。
+- Codex 额度按“刷新间隔”设置更新；底部使用统计、近 7 天图和活动热力图复用 1 小时缓存。底部统计与热力图始终采用官方数据，只有近 7 天图会在接口缺少当天记录时使用本机会话日志估算，次日同步后由官方数据替换。
 - Codex 默认读取本机 CLI 目录；非默认位置通过只读目录选择器设置，并兼容旧版已保存的 `auth.json` 文件路径。
 - DeepSeek 支持峰谷计价提示；MiMo Cookie 可通过专用 Chrome 会话获取和续期。
-- 网络异常时保留最近一次成功额度，并继续更新本地 Token 活动；本地统计不会覆盖远程额度更新时间。
+- 面板状态栏和悬浮提示会区分接口、缓存与近 7 天当天估算数据；断网、超时、限流及服务异常时按匿名账号指纹恢复最后成功的额度、统计和活动数据，完全退出后离线重启也不会清空。
 - 历史数据缓存在本地 SQLite；自动更新前备份 `usage.db`，分时数据按设置天数的 2 倍保护期清理并记录清理明细。
 - API Key、Bearer Token 和 Cookie 保存到 Windows 凭据管理器。
 - 支持迁移应用数据目录、自动更新及单实例运行。

--- a/api/providers/base.py
+++ b/api/providers/base.py
@@ -67,6 +67,10 @@ class ProviderQuota:
     account_label: str = ""
     plan: str = ""
     account_plan_active_until: datetime | None = None
+    activity_source: str = ""
+    weekly_activity: tuple[tuple[str, int], ...] = ()
+    weekly_activity_source: str = ""
+    statistics_source: str = ""
 
 
 def _decimal(value: Any) -> Decimal:
@@ -138,6 +142,10 @@ class Provider:
 
     def reset_refresh_cache(self) -> None:
         """Reset data that is valid only within one refresh task."""
+
+    def snapshot_identity(self) -> str:
+        """Return a stable non-secret identity for persisted provider snapshots."""
+        return ""
 
     def close(self) -> None:
         """Release provider-owned resources."""

--- a/api/providers/codex.py
+++ b/api/providers/codex.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
 import os
 import re
 import threading
+import time
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, timezone
@@ -24,8 +26,9 @@ from api.providers.base import (
     build_session,
 )
 
-
 _TIMESTAMP = re.compile(r'^\{"timestamp":"([^"]+)"')
+_ActivityRows = tuple[tuple[str, int], ...]
+_ActivityData = tuple[_ActivityRows, _ActivityRows, tuple[QuotaMetric, ...]]
 
 
 @dataclass
@@ -36,7 +39,6 @@ class _SessionUsage:
     task_start: datetime | None = None
     longest_task_seconds: int = 0
     last_total: int = 0
-    last_cached: int = 0
     peak_total: int = 0
     daily: dict[str, int] = field(default_factory=dict)
 
@@ -59,13 +61,22 @@ class CodexProvider(Provider):
     _session_cache_lock: ClassVar[threading.Lock] = threading.Lock()
     _subscription_cache: ClassVar[dict[str, tuple[datetime, datetime]]] = {}
     _subscription_cache_ttl = timedelta(hours=6)
+    _activity_cache: ClassVar[dict[str, tuple[float, _ActivityData]]] = {}
+    _activity_cache_ttl_seconds = 60 * 60
 
     def __init__(self, config: Mapping[str, Any] | None = None) -> None:
         super().__init__(config)
         self._session = build_session()
+        # 账号统计与套餐日期属于可选慢数据，禁用自动重试，避免弱网时
+        # 两个辅助请求把已经成功的额度刷新拖住一分钟以上。
+        self._metadata_session = requests.Session()
+        self._activity_data_source = ""
+        self._weekly_activity_data_source = ""
+        self._statistics_data_source = ""
 
     def close(self) -> None:
         self._session.close()
+        self._metadata_session.close()
 
     def _home(self) -> Path:
         configured = str(self.config_get("CODEX_HOME", "")).strip()
@@ -107,6 +118,20 @@ class CodexProvider(Provider):
             return True
         except (OSError, ValueError, json.JSONDecodeError):
             return False
+
+    def snapshot_identity(self) -> str:
+        try:
+            access_token, account_id, claims = self._credentials()
+        except (OSError, ValueError, json.JSONDecodeError):
+            return ""
+        identity = (
+            account_id
+            or str(claims.get("sub") or "").strip()
+            or str(claims.get("email") or "").strip().lower()
+            or f"token:{access_token}"
+        )
+        # SQLite 只保存不可逆指纹，避免把账号 ID、邮箱或访问令牌写入缓存。
+        return hashlib.sha256(f"codex:{identity}".encode()).hexdigest()
 
     @staticmethod
     def _window_title(seconds: int, label: str = "") -> str:
@@ -167,7 +192,6 @@ class CodexProvider(Provider):
                 task_start=previous.task_start,
                 longest_task_seconds=previous.longest_task_seconds,
                 last_total=previous.last_total,
-                last_cached=previous.last_cached,
                 peak_total=previous.peak_total,
                 daily=dict(previous.daily),
             )
@@ -228,22 +252,16 @@ class CodexProvider(Provider):
                         total_usage = (
                             info.get("total_token_usage") if isinstance(info, dict) else None
                         )
+                        if not isinstance(total_usage, dict):
+                            continue
                         total = int(total_usage.get("total_tokens") or 0)
-                        cached = int(total_usage.get("cached_input_tokens") or 0)
                     except (AttributeError, TypeError, ValueError, json.JSONDecodeError):
                         continue
                     delta_total = total - usage.last_total if total >= usage.last_total else total
-                    delta_cached = (
-                        cached - usage.last_cached
-                        if cached >= usage.last_cached
-                        else cached
-                    )
-                    # Codex 客户端把缓存输入单列计入本地活动；这里沿用相同口径，
-                    # 否则累计与单聊天峰值会显著低于客户端统计页。
-                    delta = delta_total + delta_cached
+                    # total_tokens 已包含缓存输入；再次叠加 cached_input_tokens 会重复计数。
+                    delta = delta_total
                     usage.last_total = total
-                    usage.last_cached = cached
-                    usage.peak_total = max(usage.peak_total, total + cached)
+                    usage.peak_total = max(usage.peak_total, total)
                     if delta <= 0 or observed_at is None:
                         continue
                     usage_day = observed_at.astimezone().date().isoformat()
@@ -258,7 +276,9 @@ class CodexProvider(Provider):
     @staticmethod
     def _compact_tokens(value: int) -> str:
         denominator, suffix = (100_000_000, "亿") if value >= 100_000_000 else (10_000, "万")
-        text = f"{value / denominator:.2f}".rstrip("0").rstrip(".")
+        # Codex 账号页保留 1 位小数并去尾零；采用相同显示口径避免
+        # 原始值相同却因 26.08 亿/26.1 亿的精度差异看起来不一致。
+        text = f"{value / denominator:.1f}".rstrip("0").rstrip(".")
         return f"{text}{suffix}"
 
     @staticmethod
@@ -311,20 +331,200 @@ class CodexProvider(Provider):
         current_streak, longest_streak = self._streaks(active_days)
         total_tokens = sum(daily.values())
         peak_tokens = max((usage.peak_total for usage in usages), default=0)
+        detail = "服务端统计暂不可用，当前显示本机 Codex 会话日志估算"
         statistics = (
-            QuotaMetric("累计 Token 数", self._compact_tokens(total_tokens)),
-            QuotaMetric("峰值 Token 数", self._compact_tokens(peak_tokens)),
-            QuotaMetric("最长任务时长", self._duration_text(longest_seconds)),
-            QuotaMetric("当前连续天数", f"{current_streak} 天"),
-            QuotaMetric("最长连续天数", f"{longest_streak} 天"),
+            QuotaMetric("累计 Token 数", self._compact_tokens(total_tokens), detail),
+            QuotaMetric("峰值 Token 数", self._compact_tokens(peak_tokens), detail),
+            QuotaMetric("最长任务时长", self._duration_text(longest_seconds), detail),
+            QuotaMetric("当前连续天数", f"{current_streak} 天", detail),
+            QuotaMetric("最长连续天数", f"{longest_streak} 天", detail),
         )
         return tuple(sorted(daily.items())), statistics
 
+    def _activity_cache_key(
+        self, account_id: str | None, claims: Mapping[str, Any]
+    ) -> str:
+        if account_id:
+            return f"account:{account_id}"
+        email = str(claims.get("email") or "").strip().lower()
+        if email:
+            return f"email:{email}"
+        return f"home:{self._home().resolve(strict=False)}"
+
+    def _activity_snapshot(
+        self,
+        cache_key: str,
+        headers: dict[str, str] | None = None,
+    ) -> _ActivityData:
+        now = time.monotonic()
+        with self._session_cache_lock:
+            cached = self._activity_cache.get(cache_key)
+        if cached and (
+            now - cached[0] < self._activity_cache_ttl_seconds or headers is None
+        ):
+            activity, weekly_activity, statistics = cached[1]
+            self._activity_data_source = "cache" if activity else ""
+            self._weekly_activity_data_source = "cache" if weekly_activity else ""
+            self._statistics_data_source = "cache" if statistics else ""
+            return cached[1]
+
+        # 额度窗口仍按用户配置刷新；账号统计接口独立限频为一小时。
+        # 本机会话只补近 7 天图的当天值，不能污染官方热力图和底部统计。
+        local_rows, _local_statistics = self._local_activity()
+        today = datetime.now().astimezone().date().isoformat()
+        local_today_tokens = dict(local_rows).get(today, 0)
+        if headers is None:
+            weekly_activity = ((today, local_today_tokens),) if local_today_tokens else ()
+            self._activity_data_source = ""
+            self._weekly_activity_data_source = "local" if weekly_activity else ""
+            self._statistics_data_source = ""
+            return (), weekly_activity, ()
+        else:
+            profile_activity = self._profile_activity(headers)
+            # 统计接口暂时不可用时优先展示最后一次官方结果；从未成功过时
+            # 只允许近 7 天图显示本机当天估算，其他统计保持空白。
+            if profile_activity is not None:
+                activity, statistics = profile_activity
+                weekly = dict(activity)
+                merged_local_today = local_today_tokens > 0 and today not in weekly
+                if merged_local_today:
+                    weekly[today] = local_today_tokens
+                result = activity, tuple(sorted(weekly.items())), statistics
+                self._activity_data_source = "interface"
+                self._weekly_activity_data_source = (
+                    "mixed" if merged_local_today else "interface"
+                )
+                self._statistics_data_source = "interface"
+            elif cached is not None:
+                result = cached[1]
+                activity, weekly_activity, statistics = result
+                self._activity_data_source = "cache" if activity else ""
+                self._weekly_activity_data_source = "cache" if weekly_activity else ""
+                self._statistics_data_source = "cache" if statistics else ""
+            else:
+                weekly_activity = (
+                    ((today, local_today_tokens),) if local_today_tokens else ()
+                )
+                result = (), weekly_activity, ()
+                self._activity_data_source = ""
+                self._weekly_activity_data_source = (
+                    "local" if weekly_activity else ""
+                )
+                self._statistics_data_source = ""
+        with self._session_cache_lock:
+            self._activity_cache[cache_key] = (time.monotonic(), result)
+        return result
+
+    def _local_only_quota(self, cache_key: str) -> ProviderQuota | None:
+        activity, weekly_activity, statistics = self._activity_snapshot(cache_key)
+        return (
+            ProviderQuota(
+                activity=activity,
+                statistics=statistics,
+                activity_source=self._activity_data_source,
+                weekly_activity=weekly_activity,
+                weekly_activity_source=self._weekly_activity_data_source,
+                statistics_source=self._statistics_data_source,
+            )
+            if activity or weekly_activity or statistics
+            else None
+        )
+
     @staticmethod
-    def _local_only_quota(
-        activity: tuple[tuple[str, int], ...], statistics: tuple[QuotaMetric, ...]
-    ) -> ProviderQuota | None:
-        return ProviderQuota(activity=activity, statistics=statistics) if activity else None
+    def _nonnegative_int(value: Any) -> int | None:
+        try:
+            return max(0, int(value))
+        except (TypeError, ValueError):
+            return None
+
+    def _profile_activity(
+        self, headers: dict[str, str]
+    ) -> tuple[tuple[tuple[str, int], ...], tuple[QuotaMetric, ...]] | None:
+        try:
+            response = self._metadata_session.get(
+                "https://chatgpt.com/backend-api/wham/profiles/me",
+                headers=headers,
+                timeout=(3, 5),
+            )
+        except requests.RequestException:
+            return None
+        if not response.ok:
+            return None
+        try:
+            payload = response.json()
+        except (requests.JSONDecodeError, ValueError):
+            return None
+        if not isinstance(payload, dict):
+            return None
+        metadata = payload.get("metadata")
+        if isinstance(metadata, dict) and str(metadata.get("stats_error") or "").strip():
+            return None
+        stats = payload.get("stats")
+        if not isinstance(stats, dict):
+            return None
+
+        daily: dict[str, int] = {}
+        buckets = stats.get("daily_usage_buckets")
+        if isinstance(buckets, list):
+            for bucket in buckets:
+                if not isinstance(bucket, dict):
+                    continue
+                usage_day = str(bucket.get("start_date") or "").strip()
+                try:
+                    date.fromisoformat(usage_day)
+                except ValueError:
+                    continue
+                tokens = self._nonnegative_int(bucket.get("tokens"))
+                if tokens is None:
+                    continue
+                daily[usage_day] = daily.get(usage_day, 0) + tokens
+
+        total_tokens = self._nonnegative_int(stats.get("lifetime_tokens"))
+        peak_tokens = self._nonnegative_int(stats.get("peak_daily_tokens"))
+        longest_seconds = self._nonnegative_int(stats.get("longest_running_turn_sec"))
+        current_streak = self._nonnegative_int(stats.get("current_streak_days"))
+        longest_streak = self._nonnegative_int(stats.get("longest_streak_days"))
+        if not daily and all(
+            value is None
+            for value in (
+                total_tokens,
+                peak_tokens,
+                longest_seconds,
+                current_streak,
+                longest_streak,
+            )
+        ):
+            return None
+
+        detail = "来自 Codex 账号统计"
+        statistics = (
+            QuotaMetric(
+                "累计 Token 数",
+                "--" if total_tokens is None else self._compact_tokens(total_tokens),
+                detail,
+            ),
+            QuotaMetric(
+                "峰值 Token 数",
+                "--" if peak_tokens is None else self._compact_tokens(peak_tokens),
+                detail,
+            ),
+            QuotaMetric(
+                "最长任务时长",
+                "--" if longest_seconds is None else self._duration_text(longest_seconds),
+                detail,
+            ),
+            QuotaMetric(
+                "当前连续天数",
+                "--" if current_streak is None else f"{current_streak} 天",
+                detail,
+            ),
+            QuotaMetric(
+                "最长连续天数",
+                "--" if longest_streak is None else f"{longest_streak} 天",
+                detail,
+            ),
+        )
+        return tuple(sorted(daily.items())), statistics
 
     def _subscription_active_until(
         self, headers: dict[str, str], account_id: str
@@ -338,11 +538,11 @@ class CodexProvider(Provider):
             if now - cached_at < self._subscription_cache_ttl and active_until > active_now:
                 return active_until
         try:
-            response = self._session.get(
+            response = self._metadata_session.get(
                 "https://chatgpt.com/backend-api/subscriptions",
                 headers=headers,
                 params={"account_id": account_id},
-                timeout=(5, 20),
+                timeout=(3, 5),
             )
         except requests.RequestException:
             return None
@@ -361,7 +561,6 @@ class CodexProvider(Provider):
         return active_until
 
     def fetch_quota(self) -> tuple[ProviderQuota | None, FetchError | None]:
-        activity, statistics = self._local_activity()
         try:
             access_token, account_id, claims = self._credentials()
         except (OSError, ValueError, json.JSONDecodeError):
@@ -372,33 +571,35 @@ class CodexProvider(Provider):
             "Authorization": f"Bearer {access_token}",
             "Accept": "application/json",
             "User-Agent": "TokenMeter",
+            "originator": "Codex Desktop",
         }
         if account_id:
             headers["ChatGPT-Account-Id"] = account_id
+        activity_cache_key = self._activity_cache_key(account_id, claims)
         try:
             response = self._session.get(
                 "https://chatgpt.com/backend-api/wham/usage",
                 headers=headers,
-                timeout=(5, 20),
+                timeout=(3, 10),
             )
         except requests.Timeout:
-            return self._local_only_quota(activity, statistics), FetchError(
+            return self._local_only_quota(activity_cache_key), FetchError(
                 "NETWORK_TIMEOUT", "Codex 订阅额度", "连接 Codex 额度服务超时"
             )
         except requests.RequestException:
-            return self._local_only_quota(activity, statistics), FetchError(
+            return self._local_only_quota(activity_cache_key), FetchError(
                 "NETWORK_ERROR", "Codex 订阅额度", "无法连接 Codex 额度服务"
             )
         if response.status_code in (401, 403):
-            return self._local_only_quota(activity, statistics), FetchError(
+            return self._local_only_quota(activity_cache_key), FetchError(
                 "AUTH_EXPIRED", "Codex 订阅额度", "Codex 登录已过期，请运行 codex 重新登录"
             )
         if response.status_code == 429:
-            return self._local_only_quota(activity, statistics), FetchError(
+            return self._local_only_quota(activity_cache_key), FetchError(
                 "RATE_LIMITED", "Codex 订阅额度", "Codex 额度查询过于频繁"
             )
         if not response.ok:
-            return self._local_only_quota(activity, statistics), FetchError(
+            return self._local_only_quota(activity_cache_key), FetchError(
                 "SERVER_ERROR",
                 "Codex 订阅额度",
                 f"Codex 额度服务返回 HTTP {response.status_code}",
@@ -408,9 +609,13 @@ class CodexProvider(Provider):
             if not isinstance(payload, dict):
                 raise ValueError
         except (requests.JSONDecodeError, ValueError):
-            return self._local_only_quota(activity, statistics), FetchError(
+            return self._local_only_quota(activity_cache_key), FetchError(
                 "INVALID_RESPONSE", "Codex 订阅额度", "Codex 额度数据结构已变化"
             )
+
+        activity, weekly_activity, statistics = self._activity_snapshot(
+            activity_cache_key, headers
+        )
 
         rate_limit = payload.get("rate_limit") or {}
         windows = [
@@ -452,6 +657,10 @@ class CodexProvider(Provider):
             account_label=email,
             plan=str(payload.get("plan_type") or ""),
             account_plan_active_until=active_until,
+            activity_source=self._activity_data_source,
+            weekly_activity=weekly_activity,
+            weekly_activity_source=self._weekly_activity_data_source,
+            statistics_source=self._statistics_data_source,
         ), None
 
 

--- a/data/history.py
+++ b/data/history.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 import threading
 from contextlib import closing, contextmanager
@@ -134,6 +135,65 @@ def _connect() -> Iterator[sqlite3.Connection]:
     finally:
         # sqlite Connection 的上下文只处理事务，文件句柄仍需显式关闭。
         connection.close()
+
+
+def _ensure_provider_quota_snapshot_schema(connection: sqlite3.Connection) -> None:
+    # 额度快照是新增的可选缓存，按需建表，避免只读历史查询被一次迁移阻断。
+    connection.execute(
+        """CREATE TABLE IF NOT EXISTS provider_quota_snapshot (
+               provider TEXT NOT NULL,
+               account_key TEXT NOT NULL,
+               payload TEXT NOT NULL,
+               saved_at TEXT NOT NULL,
+               PRIMARY KEY (provider, account_key)
+           )"""
+    )
+
+
+def save_provider_quota_snapshot(
+    provider: str,
+    account_key: str,
+    payload: dict[str, Any],
+    saved_at: datetime,
+) -> None:
+    if not provider or not account_key:
+        return
+    serialized = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    with _connect() as connection:
+        _ensure_provider_quota_snapshot_schema(connection)
+        connection.execute(
+            """INSERT INTO provider_quota_snapshot(provider, account_key, payload, saved_at)
+                 VALUES (?, ?, ?, ?)
+                 ON CONFLICT(provider, account_key) DO UPDATE SET
+                   payload = excluded.payload,
+                   saved_at = excluded.saved_at""",
+            (provider, account_key, serialized, saved_at.isoformat()),
+        )
+
+
+def load_provider_quota_snapshot(
+    provider: str, account_key: str
+) -> tuple[dict[str, Any], datetime] | None:
+    if not provider or not account_key:
+        return None
+    with _connect() as connection:
+        _ensure_provider_quota_snapshot_schema(connection)
+        row = connection.execute(
+            """SELECT payload, saved_at FROM provider_quota_snapshot
+                 WHERE provider = ? AND account_key = ?""",
+            (provider, account_key),
+        ).fetchone()
+    if row is None:
+        return None
+    try:
+        payload = json.loads(str(row[0]))
+        saved_at = datetime.fromisoformat(str(row[1]))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        config_manager.logger().warning(
+            "Skipped malformed provider quota snapshot: provider=%s", provider
+        )
+        return None
+    return (payload, saved_at) if isinstance(payload, dict) else None
 
 
 def backup_usage_database(

--- a/data/store.py
+++ b/data/store.py
@@ -4,17 +4,17 @@ from __future__ import annotations
 
 import copy
 import threading
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal, InvalidOperation
-from collections.abc import Mapping
 from typing import Any, ClassVar
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-import api.deepseek as ds  # 兼容 v1.0 中对 data.store.ds 的测试和扩展引用。
-from config import runtime as config_manager
+import api.deepseek as ds  # noqa: F401  # 兼容 v1.0 中对 data.store.ds 的测试和扩展引用。
 from api.providers import active_providers
 from api.providers.base import FetchError, ModelUsage, QuotaMetric, QuotaWindow
+from config import runtime as config_manager
 from data import history
 
 TOKEN_TYPES = {
@@ -24,6 +24,14 @@ TOKEN_TYPES = {
 }
 ACTIVITY_DAYS = 365
 HISTORY_SYNC_BATCH_SIZE = 2
+_TRANSIENT_QUOTA_ERROR_CODES = {
+    "INVALID_RESPONSE",
+    "NETWORK_ERROR",
+    "NETWORK_TIMEOUT",
+    "RATE_LIMITED",
+    "SERVER_ERROR",
+    "UNKNOWN_ERROR",
+}
 
 
 def top_model_stats(
@@ -295,6 +303,10 @@ class PerProviderData:
     account_label: str = ""
     account_plan: str = ""
     account_plan_active_until: datetime | None = None
+    quota_source: str = ""
+    activity_source: str = ""
+    weekly_activity_source: str = ""
+    statistics_source: str = ""
     errors: list[FetchError] = field(default_factory=list)
     status: str = "loading"
     is_stale: bool = False
@@ -322,6 +334,10 @@ class TokenData:
     account_label: str = ""
     account_plan: str = ""
     account_plan_active_until: datetime | None = None
+    quota_source: str = ""
+    activity_source: str = ""
+    weekly_activity_source: str = ""
+    statistics_source: str = ""
     status: str = "loading"
     last_success_at: datetime | None = None
     last_attempt_at: datetime | None = None
@@ -329,6 +345,7 @@ class TokenData:
     is_stale: bool = False
     last_updated: str = ""
     daily_usage: list[dict[str, Any]] = field(default_factory=list)
+    weekly_usage: list[dict[str, Any]] = field(default_factory=list)
     minute_usage: list[dict[str, Any]] = field(default_factory=list)
     minute_usage_status: str = "unavailable"
     minute_usage_date: str = ""
@@ -427,6 +444,254 @@ class TokenData:
             return copy.deepcopy(snapshot) if snapshot else None
 
     @classmethod
+    def persisted_snapshot(
+        cls, config: Mapping[str, Any] | None = None
+    ) -> "TokenData | None":
+        """Load the selected account's disk snapshot without making a network call."""
+        providers = list(active_providers(config))
+        if not providers:
+            return None
+        provider = providers[0]
+        try:
+            if not getattr(provider, "supports_subscription_quota", False):
+                return None
+            snapshot = cls._load_persisted_quota_snapshot(provider)
+            if snapshot is not None:
+                with cls._cache_lock:
+                    cls._provider_snapshots[provider.id] = copy.deepcopy(snapshot)
+            return snapshot
+        except Exception:
+            config_manager.logger().exception(
+                "Persisted quota snapshot preload failed for %s", provider.id
+            )
+            return None
+        finally:
+            close = getattr(provider, "close", None)
+            if close is not None:
+                close()
+
+    @staticmethod
+    def _snapshot_identity(provider) -> str:
+        identity_getter = getattr(provider, "snapshot_identity", None)
+        if not callable(identity_getter):
+            return ""
+        try:
+            return str(identity_getter() or "").strip()
+        except Exception:
+            config_manager.logger().warning(
+                "Provider snapshot identity failed: provider=%s", provider.id
+            )
+            return ""
+
+    @classmethod
+    def _load_persisted_quota_snapshot(cls, provider) -> "TokenData | None":
+        account_key = cls._snapshot_identity(provider)
+        record = history.load_provider_quota_snapshot(provider.id, account_key)
+        if record is None:
+            return None
+        payload, saved_at = record
+        try:
+            snapshot_version = int(payload.get("version") or 0)
+        except (TypeError, ValueError):
+            snapshot_version = 0
+
+        def parsed_datetime(value: Any) -> datetime | None:
+            if not value:
+                return None
+            return datetime.fromisoformat(str(value))
+
+        def parsed_metrics(key: str) -> list[QuotaMetric]:
+            result: list[QuotaMetric] = []
+            values = payload.get(key)
+            if not isinstance(values, list):
+                return result
+            for item in values:
+                if not isinstance(item, dict):
+                    continue
+                result.append(
+                    QuotaMetric(
+                        str(item.get("title") or ""),
+                        str(item.get("value") or ""),
+                        str(item.get("detail") or ""),
+                    )
+                )
+            return result
+
+        try:
+            windows: list[QuotaWindow] = []
+            window_values = payload.get("windows")
+            if isinstance(window_values, list):
+                for item in window_values:
+                    if not isinstance(item, dict):
+                        continue
+                    minutes = item.get("window_minutes")
+                    windows.append(
+                        QuotaWindow(
+                            str(item.get("id") or ""),
+                            str(item.get("title") or ""),
+                            max(0.0, min(100.0, float(item.get("used_percent") or 0))),
+                            resets_at=parsed_datetime(item.get("resets_at")),
+                            window_minutes=None if minutes is None else int(minutes),
+                            detail=str(item.get("detail") or ""),
+                        )
+                    )
+            metrics = parsed_metrics("metrics")
+            statistics = parsed_metrics("statistics")
+
+            def parsed_activity(key: str) -> list[dict[str, Any]]:
+                result: list[dict[str, Any]] = []
+                activity_values = payload.get(key)
+                if not isinstance(activity_values, list):
+                    return result
+                for item in activity_values:
+                    if not isinstance(item, list) or len(item) != 2:
+                        continue
+                    usage_day = date.fromisoformat(str(item[0])).isoformat()
+                    result.append(
+                        {
+                            "date": usage_day,
+                            "tokens": max(0, int(item[1])),
+                            "cost_cny": 0,
+                        }
+                    )
+                return result
+
+            daily_usage = parsed_activity("activity")
+            weekly_usage = parsed_activity("weekly_activity")
+            if snapshot_version < 3:
+                official_statistics = bool(statistics) and all(
+                    metric.detail == "来自 Codex 账号统计"
+                    for metric in statistics
+                )
+                if official_statistics:
+                    # 旧缓存只有统计项的 detail 能证明接口来源。热力图删除
+                    # 当天这个历史上可能被估算合并的位置；近 7 天仍可保留
+                    # 当前自然日的独立值，不让它进入官方活动序列。
+                    today_key = date.today().isoformat()
+                    legacy_weekly = weekly_usage or list(daily_usage)
+                    daily_usage = [
+                        item for item in daily_usage if item["date"] != today_key
+                    ]
+                    weekly_by_date = {
+                        str(item["date"]): dict(item) for item in daily_usage
+                    }
+                    for item in legacy_weekly:
+                        if item["date"] == today_key:
+                            weekly_by_date[today_key] = dict(item)
+                    weekly_usage = [
+                        weekly_by_date[usage_day]
+                        for usage_day in sorted(weekly_by_date)
+                    ]
+                else:
+                    # 本机估算或来源不明的旧快照不能冒充官方缓存。
+                    statistics = []
+                    daily_usage = []
+                    weekly_usage = []
+            active_until = parsed_datetime(payload.get("account_plan_active_until"))
+        except (TypeError, ValueError):
+            config_manager.logger().warning(
+                "Skipped invalid persisted quota snapshot: provider=%s", provider.id
+            )
+            return None
+
+        currency = str(
+            payload.get("currency")
+            or getattr(provider, "default_currency", "CNY")
+            or "CNY"
+        ).upper()
+        plan = str(payload.get("account_plan") or "")
+        per = PerProviderData(
+            provider.id,
+            provider.name,
+            currency=currency,
+            quota_windows=windows,
+            quota_metrics=metrics,
+            quota_statistics=statistics,
+            account_plan=plan,
+            account_plan_active_until=active_until,
+            quota_source="cache",
+            activity_source="cache" if daily_usage else "",
+            weekly_activity_source="cache" if weekly_usage else "",
+            statistics_source="cache" if statistics else "",
+            status="ok",
+            is_stale=True,
+        )
+        return cls(
+            currency=currency,
+            per_provider=[per],
+            quota_windows=list(windows),
+            quota_metrics=list(metrics),
+            quota_statistics=list(statistics),
+            account_plan=plan,
+            account_plan_active_until=active_until,
+            quota_source="cache",
+            activity_source="cache" if daily_usage else "",
+            weekly_activity_source="cache" if weekly_usage else "",
+            statistics_source="cache" if statistics else "",
+            status="ok",
+            last_success_at=saved_at,
+            is_stale=True,
+            last_updated=saved_at.strftime("%H:%M:%S"),
+            daily_usage=daily_usage,
+            weekly_usage=weekly_usage,
+        )
+
+    @classmethod
+    def _save_persisted_quota_snapshot(cls, provider, data: "TokenData") -> None:
+        account_key = cls._snapshot_identity(provider)
+        if not account_key or not data.per_provider or data.last_success_at is None:
+            return
+        per = data.per_provider[0]
+
+        def metric_payload(metric: QuotaMetric) -> dict[str, str]:
+            return {
+                "title": metric.title,
+                "value": metric.value,
+                "detail": metric.detail,
+            }
+
+        payload: dict[str, Any] = {
+            "version": 3,
+            "currency": per.currency,
+            "windows": [
+                {
+                    "id": window.id,
+                    "title": window.title,
+                    "used_percent": window.used_percent,
+                    "resets_at": (
+                        window.resets_at.isoformat() if window.resets_at else None
+                    ),
+                    "window_minutes": window.window_minutes,
+                    "detail": window.detail,
+                }
+                for window in per.quota_windows
+            ],
+            "metrics": [metric_payload(metric) for metric in per.quota_metrics],
+            "statistics": [
+                metric_payload(metric) for metric in per.quota_statistics
+            ],
+            "activity": [
+                [str(item.get("date") or ""), int(item.get("tokens") or 0)]
+                for item in data.daily_usage
+                if item.get("date")
+            ],
+            "weekly_activity": [
+                [str(item.get("date") or ""), int(item.get("tokens") or 0)]
+                for item in data.weekly_usage
+                if item.get("date")
+            ],
+            "account_plan": per.account_plan,
+            "account_plan_active_until": (
+                per.account_plan_active_until.isoformat()
+                if per.account_plan_active_until
+                else None
+            ),
+        }
+        history.save_provider_quota_snapshot(
+            provider.id, account_key, payload, data.last_success_at
+        )
+
+    @classmethod
     def fetch(
         cls,
         today: date | None = None,
@@ -465,6 +730,19 @@ class TokenData:
         observed_at = provider_observed_at(provider.id, datetime.now().astimezone())
         current_day = today or observed_at.date()
         cached = cls._base_snapshot(provider.id)
+        if (
+            not cached.per_provider
+            and getattr(provider, "supports_subscription_quota", False)
+        ):
+            try:
+                persisted = cls._load_persisted_quota_snapshot(provider)
+            except Exception:
+                config_manager.logger().exception(
+                    "Persisted quota snapshot read failed for %s", provider.id
+                )
+            else:
+                if persisted is not None:
+                    cached = persisted
         data = cached
         data.status = "loading"
         data.errors = []
@@ -484,12 +762,17 @@ class TokenData:
         per.account_label = ""
         per.account_plan = ""
         per.account_plan_active_until = None
+        per.quota_source = ""
+        per.activity_source = ""
+        per.weekly_activity_source = ""
+        per.statistics_source = ""
         per.errors = []
         per.status = "loading"
         per.is_stale = False
         successes = 0
         kept_cached_quota = False
         quota_refresh_failed = False
+        quota_refresh_succeeded = False
         minute_rows: list[dict[str, Any]] = []
         minute_cost_rows: list[dict[str, Any]] = []
         minute_status = "unavailable"
@@ -534,6 +817,7 @@ class TokenData:
             )
             per.errors.append(FetchError("NOT_CONFIGURED", provider.name, f"尚未配置 {provider.name} 凭据"))
             data.daily_usage = []
+            data.weekly_usage = []
             data.last_success_at = None
             data.last_updated = ""
         else:
@@ -548,25 +832,40 @@ class TokenData:
                 quota_error
                 and getattr(provider, "supports_subscription_quota", False)
             )
+            quota_refresh_succeeded = bool(
+                quota is not None
+                and quota_error is None
+                and getattr(provider, "supports_subscription_quota", False)
+            )
             kept_cached_quota = bool(
                 quota_error
-                and quota_error.code in {"NETWORK_ERROR", "NETWORK_TIMEOUT"}
+                and quota_error.code in _TRANSIENT_QUOTA_ERROR_CODES
                 and previous_per
                 and (
                     previous_per.quota_windows
                     or previous_per.quota_metrics
+                    or previous_per.quota_statistics
                     or previous_per.account_plan
                     or previous_per.account_plan_active_until
+                    or data.daily_usage
+                    or data.weekly_usage
                 )
             )
             if kept_cached_quota and previous_per is not None:
-                # Codex 的远程额度失败时仍会返回最新本地活动。保留上次成功
-                # 的远程额度，避免瞬时网络波动把卡片清空。
+                # 暂时性远程失败必须保留整份最后成功快照，避免额度、统计和
+                # 活动图分别回退到不同时间点的数据。
                 per.quota_windows = copy.deepcopy(previous_per.quota_windows)
                 per.quota_metrics = copy.deepcopy(previous_per.quota_metrics)
+                per.quota_statistics = copy.deepcopy(previous_per.quota_statistics)
                 per.account_label = previous_per.account_label
                 per.account_plan = previous_per.account_plan
                 per.account_plan_active_until = previous_per.account_plan_active_until
+                per.quota_source = "cache"
+                per.activity_source = "cache" if data.daily_usage else ""
+                per.weekly_activity_source = "cache" if data.weekly_usage else ""
+                per.statistics_source = (
+                    "cache" if previous_per.quota_statistics else ""
+                )
             if quota is not None:
                 if not kept_cached_quota:
                     per.quota_windows = list(quota.windows)
@@ -574,11 +873,68 @@ class TokenData:
                     per.account_label = quota.account_label
                     per.account_plan = quota.plan
                     per.account_plan_active_until = quota.account_plan_active_until
-                per.quota_statistics = list(quota.statistics)
-                data.daily_usage = [
-                    {"date": usage_day, "tokens": tokens, "cost_cny": 0}
-                    for usage_day, tokens in quota.activity
-                ]
+                    per.quota_source = "interface" if quota_error is None else ""
+
+                    if quota.activity_source or quota.activity:
+                        data.daily_usage = [
+                            {"date": usage_day, "tokens": tokens, "cost_cny": 0}
+                            for usage_day, tokens in quota.activity
+                        ]
+                        per.activity_source = quota.activity_source or "interface"
+                    elif data.daily_usage:
+                        # 额度接口与账号统计接口相互独立；后者失败不能清空
+                        # 跨重启恢复出的最后一份官方热力图。
+                        per.activity_source = "cache"
+                    else:
+                        data.daily_usage = []
+                        per.activity_source = ""
+
+                    if quota.statistics_source or quota.statistics:
+                        per.quota_statistics = list(quota.statistics)
+                        per.statistics_source = (
+                            quota.statistics_source or "interface"
+                        )
+                    elif previous_per and previous_per.quota_statistics:
+                        per.quota_statistics = copy.deepcopy(
+                            previous_per.quota_statistics
+                        )
+                        per.statistics_source = "cache"
+                    else:
+                        per.quota_statistics = []
+                        per.statistics_source = ""
+
+                    weekly_activity = quota.weekly_activity or quota.activity
+                    weekly_usage = [
+                        {"date": usage_day, "tokens": tokens, "cost_cny": 0}
+                        for usage_day, tokens in weekly_activity
+                    ]
+                    if quota.weekly_activity_source == "local" and data.weekly_usage:
+                        # 统计接口刚好离线时保留缓存历史，只覆盖本机明确提供的
+                        # 当天估算；这样不会用本机日志重算任何历史日期。
+                        merged_weekly = {
+                            str(item.get("date") or ""): dict(item)
+                            for item in data.weekly_usage
+                            if item.get("date")
+                        }
+                        for item in weekly_usage:
+                            merged_weekly[str(item["date"])] = item
+                        data.weekly_usage = [
+                            merged_weekly[usage_day]
+                            for usage_day in sorted(merged_weekly)
+                        ]
+                        per.weekly_activity_source = "cache_mixed"
+                    elif quota.weekly_activity_source or weekly_activity:
+                        data.weekly_usage = weekly_usage
+                        per.weekly_activity_source = (
+                            quota.weekly_activity_source
+                            or per.activity_source
+                            or "interface"
+                        )
+                    elif data.weekly_usage:
+                        per.weekly_activity_source = "cache"
+                    else:
+                        data.weekly_usage = []
+                        per.weekly_activity_source = ""
                 successes += 1
             elif kept_cached_quota:
                 # 没有本地活动时也继续展示上一份完整额度。
@@ -770,7 +1126,7 @@ class TokenData:
 
             if successes:
                 per.status = "partial" if per.errors else "ok"
-                per.is_stale = bool(per.errors)
+                per.is_stale = bool(per.errors) or kept_cached_quota
             else:
                 per.status = "error"
                 per.is_stale = previous_per is not None
@@ -794,6 +1150,10 @@ class TokenData:
         data.account_label = per.account_label
         data.account_plan = per.account_plan
         data.account_plan_active_until = per.account_plan_active_until
+        data.quota_source = per.quota_source
+        data.activity_source = per.activity_source
+        data.weekly_activity_source = per.weekly_activity_source
+        data.statistics_source = per.statistics_source
         data.errors = list(per.errors)
         data.minute_usage = minute_rows
         data.minute_usage_status = minute_status
@@ -808,9 +1168,17 @@ class TokenData:
                 data.last_success_at = datetime.now()
                 data.last_updated = data.last_success_at.strftime("%H:%M:%S")
             data.status = "partial" if per.errors else "ok"
-            data.is_stale = bool(per.errors)
+            data.is_stale = per.is_stale
             with cls._cache_lock:
                 cls._provider_snapshots[provider.id] = copy.deepcopy(data)
+            if quota_refresh_succeeded:
+                try:
+                    cls._save_persisted_quota_snapshot(provider, data)
+                except Exception:
+                    # 缓存落盘失败不能把一次成功的远程刷新降级为界面错误。
+                    config_manager.logger().exception(
+                        "Persisted quota snapshot write failed for %s", provider.id
+                    )
         else:
             data.status = "error" if per.status != "not_configured" else "not_configured"
             data.is_stale = per.is_stale

--- a/docs/V2_ROADMAP.md
+++ b/docs/V2_ROADMAP.md
@@ -27,7 +27,7 @@ Codex 额度语义参考 [CodexBar Codex Provider](https://github.com/steipete/C
 - 增加通用 `ProviderQuota`、`QuotaWindow` 和 `QuotaMetric` 数据结构。
 - Provider 注册表收缩为 DeepSeek、MiMo、Codex，继续复用现有连接测试、快照隔离和错误状态。
 - Codex 读取本机 OAuth 登录，查询主窗口、次窗口、专项限额与 Credits。
-- Codex 只解析本机 `sessions/**/*.jsonl` 中的时间戳和 `token_count` 事件，生成年度活动热力图及五项本地统计，不读取或上传对话正文。
+- Codex 从账号资料统计端点读取年度活动与五项统计；本机会话日志只补近 7 天图中接口缺失的当天 Token，不能写入年度热力图或底部统计，也不读取或上传对话正文。
 - 顶栏保留一个 Provider 下拉框，切换后立即清空旧范围并刷新，避免跨 Provider 短暂错标。
 - 主面板、统计区和悬浮球根据 Provider 能力自动切换“订阅额度”或“API 账单”视图。
 - Codex 左侧额度卡展示已用/剩余比例和重置倒计时，右侧展示近 7 天 Token 使用量；套餐、账号和附加额度动态填充。
@@ -36,12 +36,12 @@ Codex 额度语义参考 [CodexBar Codex Provider](https://github.com/steipete/C
 
 CodexBar 的这类能力依赖本机 CLI OAuth 会话和产品内部额度端点，并不等同于 OpenAI Admin API。TokenMeter 只读取用户已经登录的本机凭据文件，不采集密码。
 
-内部额度端点可能随产品更新而变化，因此每个 Provider 独立解析、独立报错。认证失败不会回退到估算数据，也不会把上一个账号或 Provider 的缓存重新标成当前额度。
+内部额度端点可能随产品更新而变化，因此每个 Provider 独立解析、独立报错。远程额度与本机估算会明确区分，也不会把上一个账号或 Provider 的缓存重新标成当前额度。
 
 当前基础批次还有这些明确限制：
 
 - Codex 尚未加入 `codex app-server` JSON-RPC 回退和 OAuth 自动刷新。
-- 本地统计以现有 Codex JSONL 为准；已删除或不在 `CODEX_HOME` 中的会话不会被计入。
+- 资料统计端点不可用时，年度热力图与底部统计保留最后成功缓存；仅近 7 天图的当天值可用现有 Codex JSONL 估算。
 
 ## 后续发布批次
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -15,7 +15,7 @@ os.environ["APPDATA"] = str(Path.cwd() / ".test-appdata")
 import config_manager
 from api.deepseek import APIError
 from api.providers import configured_provider_ids
-from api.providers.base import build_session
+from api.providers.base import QuotaMetric, build_session
 from api.providers.codex import CodexProvider
 from api.providers.deepseek import DeepSeekProvider
 from api.providers.mimo import MiMoProvider
@@ -86,18 +86,36 @@ class MultiProviderTests(unittest.TestCase):
             return_value=((('2026-08-09', 12_000),), ())
         )
         provider._session.get = Mock(
+            return_value=response(
+                {
+                    "plan_type": "pro",
+                    "rate_limit": {
+                        "primary_window": {
+                            "used_percent": 27,
+                            "reset_at": 1785816000,
+                            "limit_window_seconds": 604800,
+                        },
+                    },
+                    "credits": {"has_credits": True, "balance": "14.5"},
+                }
+            )
+        )
+        provider._metadata_session.get = Mock(
             side_effect=[
                 response(
                     {
-                        "plan_type": "pro",
-                        "rate_limit": {
-                            "primary_window": {
-                                "used_percent": 27,
-                                "reset_at": 1785816000,
-                                "limit_window_seconds": 604800,
-                            },
+                        "stats": {
+                            "lifetime_tokens": 2_607_632_527,
+                            "peak_daily_tokens": 202_936_827,
+                            "longest_running_turn_sec": 3_155,
+                            "current_streak_days": 4,
+                            "longest_streak_days": 27,
+                            "daily_usage_buckets": [
+                                {"start_date": "2026-04-02", "tokens": 6_124_138},
+                                {"start_date": "2026-08-12", "tokens": 202_936_827},
+                            ],
                         },
-                        "credits": {"has_credits": True, "balance": "14.5"},
+                        "metadata": {},
                     }
                 ),
                 response({"active_until": "2026-08-11T06:17:00Z"}),
@@ -117,20 +135,245 @@ class MultiProviderTests(unittest.TestCase):
             quota.account_plan_active_until,
             datetime(2026, 8, 11, 6, 17, tzinfo=timezone.utc),
         )
-        self.assertEqual(quota.activity, (("2026-08-09", 12_000),))
-        self.assertEqual(provider._session.get.call_count, 2)
+        self.assertEqual(quota.activity, (
+            ("2026-04-02", 6_124_138),
+            ("2026-08-12", 202_936_827),
+        ))
         self.assertEqual(
-            provider._session.get.call_args_list[1].kwargs["params"],
+            [item.value for item in quota.statistics],
+            ["26.1亿", "2亿", "52分 35秒", "4 天", "27 天"],
+        )
+        self.assertTrue(
+            all(item.detail == "来自 Codex 账号统计" for item in quota.statistics)
+        )
+        self.assertEqual(provider._session.get.call_count, 1)
+        self.assertEqual(provider._metadata_session.get.call_count, 2)
+        self.assertEqual(
+            provider._metadata_session.get_adapter("https://").max_retries.total,
+            0,
+        )
+        self.assertEqual(
+            provider._session.get.call_args_list[0].kwargs["headers"]["originator"],
+            "Codex Desktop",
+        )
+        self.assertEqual(
+            provider._session.get.call_args_list[0].kwargs["timeout"], (3, 10)
+        )
+        self.assertTrue(
+            all(
+                call.kwargs["timeout"] == (3, 5)
+                for call in provider._metadata_session.get.call_args_list
+            )
+        )
+        self.assertEqual(
+            provider._metadata_session.get.call_args_list[1].kwargs["params"],
             {"account_id": "account"},
         )
+
+    def test_codex_refreshes_quota_without_refetching_recent_activity(self):
+        claims = {"email": "activity-cache@example.com"}
+        cache_key = "email:activity-cache@example.com"
+        today = datetime.now().astimezone().date()
+        yesterday = today - timedelta(days=1)
+        with CodexProvider._session_cache_lock:
+            CodexProvider._activity_cache.pop(cache_key, None)
+
+        first = CodexProvider()
+        second = CodexProvider()
+        first._credentials = Mock(return_value=("access", None, claims))
+        second._credentials = Mock(return_value=("access", None, claims))
+        first._local_activity = Mock(
+            return_value=(
+                (
+                    (yesterday.isoformat(), 9_999),
+                    (today.isoformat(), 7_000),
+                ),
+                (),
+            )
+        )
+        second._local_activity = Mock(return_value=((), ()))
+        first._session.get = Mock(
+            return_value=response(
+                {
+                    "rate_limit": {
+                        "primary_window": {
+                            "used_percent": 10,
+                            "reset_at": 1785816000,
+                            "limit_window_seconds": 604800,
+                        }
+                    }
+                }
+            )
+        )
+        first._metadata_session.get = Mock(
+            return_value=response(
+                {
+                    "stats": {
+                        "lifetime_tokens": 12_000,
+                        "daily_usage_buckets": [
+                            {"start_date": yesterday.isoformat(), "tokens": 3_000}
+                        ],
+                    },
+                    "metadata": {},
+                }
+            )
+        )
+        second._session.get = Mock(
+            return_value=response(
+                {
+                    "rate_limit": {
+                        "primary_window": {
+                            "used_percent": 20,
+                            "reset_at": 1785816000,
+                            "limit_window_seconds": 604800,
+                        }
+                    }
+                }
+            )
+        )
+        second._metadata_session.get = Mock()
+        try:
+            first_quota, first_error = first.fetch_quota()
+            second_quota, second_error = second.fetch_quota()
+        finally:
+            first.close()
+            second.close()
+            with CodexProvider._session_cache_lock:
+                CodexProvider._activity_cache.pop(cache_key, None)
+
+        self.assertIsNone(first_error)
+        self.assertIsNone(second_error)
+        self.assertEqual(first_quota.windows[0].used_percent, 10)
+        self.assertEqual(second_quota.windows[0].used_percent, 20)
+        self.assertEqual(second_quota.activity, first_quota.activity)
+        self.assertEqual(second_quota.weekly_activity, first_quota.weekly_activity)
+        self.assertEqual(second_quota.statistics, first_quota.statistics)
+        self.assertEqual(dict(first_quota.activity)[yesterday.isoformat()], 3_000)
+        self.assertNotIn(today.isoformat(), dict(first_quota.activity))
+        self.assertEqual(dict(first_quota.weekly_activity)[today.isoformat()], 7_000)
+        self.assertEqual(first_quota.statistics[0].value, "1.2万")
+        self.assertEqual(first_quota.statistics[0].detail, "来自 Codex 账号统计")
+        self.assertEqual(first_quota.activity_source, "interface")
+        self.assertEqual(first_quota.weekly_activity_source, "mixed")
+        self.assertEqual(first_quota.statistics_source, "interface")
+        self.assertEqual(second_quota.activity_source, "cache")
+        self.assertEqual(second_quota.weekly_activity_source, "cache")
+        self.assertEqual(second_quota.statistics_source, "cache")
+        self.assertEqual(
+            [call.args[0] for call in first._session.get.call_args_list],
+            ["https://chatgpt.com/backend-api/wham/usage"],
+        )
+        self.assertEqual(
+            [call.args[0] for call in first._metadata_session.get.call_args_list],
+            ["https://chatgpt.com/backend-api/wham/profiles/me"],
+        )
+        self.assertEqual(
+            [call.args[0] for call in second._session.get.call_args_list],
+            ["https://chatgpt.com/backend-api/wham/usage"],
+        )
+        self.assertEqual(CodexProvider._activity_cache_ttl_seconds, 3_600)
+        first._local_activity.assert_called_once_with()
+        second._local_activity.assert_not_called()
+        second._metadata_session.get.assert_not_called()
+
+    def test_codex_activity_cache_expires_after_one_hour(self):
+        cache_key = "account:activity-cache-expiry"
+        first_activity = (
+            (("2026-08-12", 3_000),),
+            (QuotaMetric("累计 Token 数", "1万"),),
+        )
+        refreshed_activity = (
+            (("2026-08-12", 4_000),),
+            (QuotaMetric("累计 Token 数", "2万"),),
+        )
+        provider = CodexProvider()
+        provider._profile_activity = Mock(
+            side_effect=[first_activity, refreshed_activity]
+        )
+        provider._local_activity = Mock(return_value=((), ()))
+        try:
+            with patch("api.providers.codex.time.monotonic", return_value=100.0):
+                initial = provider._activity_snapshot(cache_key, {})
+            with patch("api.providers.codex.time.monotonic", return_value=3_699.0):
+                cached = provider._activity_snapshot(cache_key, {})
+            with patch("api.providers.codex.time.monotonic", return_value=3_700.0):
+                refreshed = provider._activity_snapshot(cache_key, {})
+        finally:
+            provider.close()
+            with CodexProvider._session_cache_lock:
+                CodexProvider._activity_cache.pop(cache_key, None)
+
+        expected_initial = (first_activity[0], first_activity[0], first_activity[1])
+        expected_refreshed = (
+            refreshed_activity[0],
+            refreshed_activity[0],
+            refreshed_activity[1],
+        )
+        self.assertEqual(initial, expected_initial)
+        self.assertEqual(cached, expected_initial)
+        self.assertEqual(refreshed, expected_refreshed)
+        self.assertEqual(provider._profile_activity.call_count, 2)
+        self.assertEqual(provider._local_activity.call_count, 2)
+
+    def test_codex_persisted_snapshot_identity_is_stable_and_non_secret(self):
+        provider = CodexProvider()
+        provider._credentials = Mock(
+            return_value=("access-secret", "account-123", {"email": "a@example.com"})
+        )
+        try:
+            first = provider.snapshot_identity()
+            second = provider.snapshot_identity()
+            provider._credentials = Mock(
+                return_value=("other-secret", "account-456", {"email": "b@example.com"})
+            )
+            different = provider.snapshot_identity()
+        finally:
+            provider.close()
+
+        self.assertEqual(first, second)
+        self.assertEqual(len(first), 64)
+        self.assertNotIn("account-123", first)
+        self.assertNotIn("a@example.com", first)
+        self.assertNotEqual(first, different)
+
+    def test_codex_activity_failure_keeps_the_last_server_snapshot(self):
+        cache_key = "account:stale-activity-cache"
+        server_activity = (
+            (("2026-08-12", 3_000),),
+            (("2026-08-12", 3_000),),
+            (QuotaMetric("累计 Token 数", "1万", "来自 Codex 账号统计"),),
+        )
+        local_activity = (
+            (("2026-08-12", 9_000),),
+            (QuotaMetric("累计 Token 数", "9万", "本机估算"),),
+        )
+        provider = CodexProvider()
+        provider._profile_activity = Mock(return_value=None)
+        provider._local_activity = Mock(return_value=local_activity)
+        with CodexProvider._session_cache_lock:
+            CodexProvider._activity_cache[cache_key] = (100.0, server_activity)
+        try:
+            with patch("api.providers.codex.time.monotonic", return_value=3_701.0):
+                result = provider._activity_snapshot(cache_key, {})
+        finally:
+            provider.close()
+            with CodexProvider._session_cache_lock:
+                CodexProvider._activity_cache.pop(cache_key, None)
+
+        self.assertEqual(result, server_activity)
+        provider._profile_activity.assert_called_once()
+        provider._local_activity.assert_called_once_with()
 
     def test_codex_subscription_metadata_failure_does_not_discard_quota(self):
         provider = CodexProvider()
         provider._credentials = Mock(return_value=("access", "failed-account", {}))
         provider._local_activity = Mock(return_value=((), ()))
         provider._session.get = Mock(
+            return_value=response({"plan_type": "plus", "rate_limit": {}})
+        )
+        provider._metadata_session.get = Mock(
             side_effect=[
-                response({"plan_type": "plus", "rate_limit": {}}),
+                response({}, status=500),
                 requests.Timeout(),
             ]
         )
@@ -214,7 +457,7 @@ class MultiProviderTests(unittest.TestCase):
             finally:
                 provider.close()
 
-        self.assertEqual(dict(activity)[today.isoformat()], 21_000)
+        self.assertEqual(dict(activity)[today.isoformat()], 15_000)
         self.assertEqual(dict(activity)[yesterday.isoformat()], 6_000)
         self.assertEqual([item.title for item in statistics], [
             "累计 Token 数",
@@ -223,7 +466,43 @@ class MultiProviderTests(unittest.TestCase):
             "当前连续天数",
             "最长连续天数",
         ])
-        self.assertEqual([item.value for item in statistics[:3]], ["2.7万", "2.1万", "52分 35秒"])
+        self.assertEqual([item.value for item in statistics[:3]], ["2.1万", "1.5万", "52分 35秒"])
+        self.assertTrue(all("本机 Codex 会话日志估算" in item.detail for item in statistics))
+
+    def test_codex_profile_stats_error_falls_back_to_local_activity(self):
+        today = datetime.now().astimezone().date().isoformat()
+        local_statistics = (
+            QuotaMetric("累计 Token 数", "1万", "本机估算"),
+        )
+        provider = CodexProvider()
+        provider._credentials = Mock(return_value=("access", None, {}))
+        provider._local_activity = Mock(
+            return_value=(((today, 10_000),), local_statistics)
+        )
+        provider._session.get = Mock(
+            return_value=response({"plan_type": "plus", "rate_limit": {}})
+        )
+        provider._metadata_session.get = Mock(
+            return_value=response(
+                {
+                    "stats": {"lifetime_tokens": 99_000},
+                    "metadata": {"stats_error": "temporarily unavailable"},
+                }
+            )
+        )
+        try:
+            quota, error = provider.fetch_quota()
+        finally:
+            provider.close()
+
+        self.assertIsNone(error)
+        self.assertEqual(quota.activity, ())
+        self.assertEqual(quota.weekly_activity, ((today, 10_000),))
+        self.assertEqual(quota.statistics, ())
+        self.assertEqual(quota.weekly_activity_source, "local")
+        self.assertEqual(quota.activity_source, "")
+        self.assertEqual(quota.statistics_source, "")
+        provider._local_activity.assert_called_once_with()
 
 
 class MiMoProviderTests(unittest.TestCase):

--- a/tests/test_qt_ui.py
+++ b/tests/test_qt_ui.py
@@ -49,6 +49,7 @@ from ui.qt_panel import (
     MinuteUsageChart,
     StatisticsCard,
     TrendCard,
+    format_codex_tokens,
     format_money,
     format_money_axis,
     format_reset_countdown,
@@ -106,6 +107,8 @@ def test_token_axis_uses_readable_units():
     assert format_token_axis(0) == "0万"
     assert format_token_axis(1_500) == "0.15万"
     assert format_token_axis(60_000_000) == "6000万"
+    assert format_codex_tokens(2_607_632_527) == "26.1亿"
+    assert format_codex_tokens(202_936_827) == "2亿"
 
 
 def test_panel_token_values_use_readable_units():
@@ -198,7 +201,7 @@ def test_panel_quick_switches_provider_and_renders_subscription_quota():
     ]
     data.quota_metrics = [QuotaMetric("可用 Credits", "12.5")]
     data.quota_statistics = [
-        QuotaMetric("累计 Token 数", "21.7亿"),
+        QuotaMetric("累计 Token 数", "21.7亿", "来自 Codex 账号统计"),
         QuotaMetric("峰值 Token 数", "1.1亿"),
         QuotaMetric("最长任务时长", "52分 35秒"),
         QuotaMetric("当前连续天数", "0 天"),
@@ -206,6 +209,12 @@ def test_panel_quick_switches_provider_and_renders_subscription_quota():
     ]
     data.account_plan = "pro"
     data.account_label = "a@example.com"
+    data.weekly_usage = [dict(row) for row in data.daily_usage]
+    data.weekly_usage[0]["tokens"] = 99_000_000
+    data.quota_source = "interface"
+    data.weekly_activity_source = "mixed"
+    data.activity_source = "interface"
+    data.statistics_source = "interface"
     data.per_provider = [
         PerProviderData(
             "codex",
@@ -254,10 +263,18 @@ def test_panel_quick_switches_provider_and_renders_subscription_quota():
     assert panel.month_card.detail.isHidden()
     assert not panel.trend.isHidden()
     assert panel.trend.title.text() == "近 7 天 Token 使用量"
+    assert panel.trend._values[-1] == 99_000_000
+    today_activity = next(day for day in panel.activity.days if day.date == date.today())
+    assert today_activity.token_count == 10_000_000
     assert "Token：" in panel.trend.tooltip_text(0)
     assert "金额" not in panel.trend.tooltip_text(0)
     assert not panel.activity_card.isHidden()
     assert panel.activity_mode_segment.isHidden()
+    assert panel.trend.title.toolTip().endswith("当天 Token 为本机会话日志估算")
+    assert panel.activity_summary.toolTip() == "来自 Codex 账号统计，不含本机估算"
+    assert panel.status_text.text() == (
+        "额度/热力图/底部统计：接口数据 · 近 7 天：接口 + 今日本机估算"
+    )
     assert [label.text() for label in panel.statistics._values] == [
         "21.7亿",
         "1.1亿",
@@ -272,6 +289,53 @@ def test_panel_quick_switches_provider_and_renders_subscription_quota():
 
     assert selected_providers == ["mimo"]
     panel.close()
+
+
+def test_codex_cached_panel_does_not_claim_background_refresh_is_data_update():
+    panel = MainPanel()
+    data = sample_data()
+    data.per_provider = [PerProviderData("codex", "Codex")]
+    data.quota_windows = [QuotaWindow("codex-weekly", "每周额度", 25)]
+    data.quota_source = "cache"
+    data.weekly_activity_source = "cache"
+    data.activity_source = "cache"
+    data.statistics_source = "cache"
+
+    panel.update_data(data, refreshing=True)
+
+    assert "正在更新" not in panel.status_text.text()
+    assert panel.status_text.text() == "额度/近 7 天/热力图/底部统计：缓存数据"
+    assert panel.updated_text.text().startswith("缓存保存于")
+    panel.close()
+
+
+def test_codex_source_summary_marks_cached_data():
+    data = TokenData(
+        quota_source="interface",
+        weekly_activity_source="cache",
+        activity_source="cache",
+        statistics_source="cache",
+    )
+
+    assert MainPanel.codex_source_summary(data) == (
+        "额度：接口数据 · 近 7 天/热力图/底部统计：缓存数据"
+    )
+    assert MainPanel.codex_source_summary(data, loading=True).startswith(
+        "正在更新 · 当前显示"
+    )
+
+    unavailable = TokenData(
+        status="ok",
+        quota_source="interface",
+        weekly_activity_source="local",
+    )
+    assert MainPanel.codex_source_summary(unavailable) == (
+        "额度：接口数据 · 近 7 天：今日本机估算 · 热力图/底部统计：暂无数据"
+    )
+    unavailable.weekly_activity_source = "cache_mixed"
+    assert "近 7 天：缓存 + 今日本机估算" in MainPanel.codex_source_summary(
+        unavailable
+    )
 
 
 def test_subscription_expiry_replaces_codex_placeholder_without_email():

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import unittest
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
@@ -18,6 +19,7 @@ from api.providers.base import (
     QuotaMetric,
     QuotaWindow,
 )
+from data import history
 from data.store import (
     PerProviderData,
     TokenData,
@@ -233,6 +235,7 @@ class StoreTests(unittest.TestCase):
         self.assertEqual(data.quota_metrics[0].value, "12")
         self.assertEqual(data.quota_statistics[0].value, "0.12万")
         self.assertEqual(data.daily_usage[0]["tokens"], 1234)
+        self.assertEqual(data.weekly_usage[0]["tokens"], 1234)
         self.assertEqual(data.account_label, "a@example.com")
         self.assertEqual(data.account_plan, "pro")
 
@@ -287,7 +290,7 @@ class StoreTests(unittest.TestCase):
 
         self.assertEqual(data.status, "ok")
         self.assertEqual(data.errors, [])
-        self.assertFalse(data.is_stale)
+        self.assertTrue(data.is_stale)
         self.assertEqual(data.quota_windows[0].used_percent, 25)
         self.assertEqual(data.quota_metrics[0].value, "12")
         self.assertEqual(data.account_label, "a@example.com")
@@ -296,10 +299,264 @@ class StoreTests(unittest.TestCase):
             data.account_plan_active_until,
             datetime(2026, 8, 11, 6, 17, tzinfo=timezone.utc),
         )
-        self.assertEqual(data.quota_statistics[0].value, "0.23万")
-        self.assertEqual(data.daily_usage[0]["tokens"], 2345)
+        self.assertEqual(data.quota_statistics[0].value, "0.12万")
+        self.assertEqual(data.daily_usage[0]["tokens"], 1234)
+        self.assertEqual(data.weekly_usage[0]["tokens"], 1234)
+        self.assertEqual(data.quota_source, "cache")
+        self.assertEqual(data.activity_source, "cache")
+        self.assertEqual(data.weekly_activity_source, "cache")
+        self.assertEqual(data.statistics_source, "cache")
         self.assertEqual(data.last_success_at, remote_success_at)
         self.assertEqual(data.last_updated, "10:30:00")
+
+    def test_codex_transient_remote_errors_keep_the_complete_cached_snapshot(self):
+        class QuotaProvider(FakeProvider):
+            id = "codex"
+            name = "Codex"
+            supports_daily_usage = False
+            supports_cost = False
+            supports_subscription_quota = True
+
+            def fetch_balance(self):
+                return None, None
+
+            def fetch_summary(self):
+                return None, None
+
+        class SuccessfulQuotaProvider(QuotaProvider):
+            def fetch_quota(self):
+                return ProviderQuota(
+                    windows=(QuotaWindow("codex-weekly", "每周额度", 25),),
+                    activity=(("2026-07-03", 1234),),
+                    weekly_activity=(("2026-07-03", 5678),),
+                    statistics=(QuotaMetric("累计 Token 数", "0.12万"),),
+                    plan="pro",
+                ), None
+
+        for error_code in (
+            "INVALID_RESPONSE",
+            "RATE_LIMITED",
+            "SERVER_ERROR",
+            "UNKNOWN_ERROR",
+        ):
+            with self.subTest(error_code=error_code):
+                TokenData._provider_snapshots = {}
+                self.fetch_with(SuccessfulQuotaProvider())
+
+                class FailedQuotaProvider(QuotaProvider):
+                    def fetch_quota(self):
+                        return None, FetchError(error_code, "Codex 订阅额度", "暂时不可用")
+
+                data = self.fetch_with(FailedQuotaProvider())
+
+                self.assertEqual(data.quota_windows[0].used_percent, 25)
+                self.assertEqual(data.quota_statistics[0].value, "0.12万")
+                self.assertEqual(data.daily_usage[0]["tokens"], 1234)
+                self.assertEqual(data.weekly_usage[0]["tokens"], 5678)
+                self.assertEqual(data.account_plan, "pro")
+                self.assertEqual(data.errors, [])
+
+    def test_codex_stats_failure_keeps_official_cache_and_merges_only_today(self):
+        class QuotaProvider(FakeProvider):
+            id = "codex"
+            name = "Codex"
+            supports_daily_usage = False
+            supports_cost = False
+            supports_subscription_quota = True
+
+            def fetch_balance(self):
+                return None, None
+
+            def fetch_summary(self):
+                return None, None
+
+        class SuccessfulQuotaProvider(QuotaProvider):
+            def fetch_quota(self):
+                return ProviderQuota(
+                    windows=(QuotaWindow("codex-weekly", "每周额度", 25),),
+                    activity=(("2026-07-02", 1234),),
+                    weekly_activity=(("2026-07-02", 1234),),
+                    statistics=(QuotaMetric("累计 Token 数", "0.12万"),),
+                    activity_source="interface",
+                    weekly_activity_source="interface",
+                    statistics_source="interface",
+                ), None
+
+        class StatsUnavailableProvider(QuotaProvider):
+            def fetch_quota(self):
+                return ProviderQuota(
+                    windows=(QuotaWindow("codex-weekly", "每周额度", 30),),
+                    weekly_activity=(("2026-07-03", 5678),),
+                    weekly_activity_source="local",
+                ), None
+
+        self.fetch_with(SuccessfulQuotaProvider())
+        data = self.fetch_with(StatsUnavailableProvider())
+
+        self.assertEqual(data.quota_windows[0].used_percent, 30)
+        self.assertEqual(data.daily_usage[0]["tokens"], 1234)
+        self.assertEqual(data.quota_statistics[0].value, "0.12万")
+        self.assertEqual(
+            {item["date"]: item["tokens"] for item in data.weekly_usage},
+            {"2026-07-02": 1234, "2026-07-03": 5678},
+        )
+        self.assertEqual(data.quota_source, "interface")
+        self.assertEqual(data.activity_source, "cache")
+        self.assertEqual(data.statistics_source, "cache")
+        self.assertEqual(data.weekly_activity_source, "cache_mixed")
+
+    def test_codex_offline_restart_restores_only_the_same_account_snapshot(self):
+        class QuotaProvider(FakeProvider):
+            id = "codex"
+            name = "Codex"
+            supports_daily_usage = False
+            supports_cost = False
+            supports_subscription_quota = True
+
+            def __init__(self, account_key: str):
+                super().__init__()
+                self.account_key = account_key
+
+            def snapshot_identity(self):
+                return self.account_key
+
+            def fetch_balance(self):
+                return None, None
+
+            def fetch_summary(self):
+                return None, None
+
+        class SuccessfulQuotaProvider(QuotaProvider):
+            def fetch_quota(self):
+                return ProviderQuota(
+                    windows=(QuotaWindow("codex-weekly", "每周额度", 25),),
+                    activity=(("2026-07-03", 1234),),
+                    weekly_activity=(("2026-07-03", 5678),),
+                    statistics=(QuotaMetric("累计 Token 数", "0.12万"),),
+                    plan="pro",
+                ), None
+
+        class FailedQuotaProvider(QuotaProvider):
+            def fetch_quota(self):
+                return None, FetchError(
+                    "NETWORK_ERROR", "Codex 订阅额度", "无法连接 Codex 额度服务"
+                )
+
+        with tempfile.TemporaryDirectory() as directory:
+            db_path = Path(directory) / "usage.db"
+            with patch.object(history, "DB_PATH", db_path):
+                successful = self.fetch_with(SuccessfulQuotaProvider("same-account"))
+                TokenData._provider_snapshots = {}
+
+                with patch(
+                    "data.store.active_providers",
+                    return_value=iter([QuotaProvider("same-account")]),
+                ):
+                    preloaded = TokenData.persisted_snapshot(
+                        {"ACTIVE_PROVIDER": "codex"}
+                    )
+                self.assertEqual(preloaded.quota_windows[0].used_percent, 25)
+                self.assertEqual(preloaded.daily_usage[0]["tokens"], 1234)
+                self.assertEqual(preloaded.weekly_usage[0]["tokens"], 5678)
+                self.assertEqual(preloaded.weekly_activity_source, "cache")
+                TokenData._provider_snapshots = {}
+
+                restored = self.fetch_with(FailedQuotaProvider("same-account"))
+                self.assertEqual(restored.quota_windows[0].used_percent, 25)
+                self.assertEqual(restored.quota_statistics[0].value, "0.12万")
+                self.assertEqual(restored.daily_usage[0]["tokens"], 1234)
+                self.assertEqual(restored.weekly_usage[0]["tokens"], 5678)
+                self.assertEqual(restored.account_plan, "pro")
+                self.assertEqual(restored.last_success_at, successful.last_success_at)
+                self.assertEqual(restored.errors, [])
+
+                TokenData._provider_snapshots = {}
+                different_account = self.fetch_with(
+                    FailedQuotaProvider("different-account")
+                )
+
+        self.assertEqual(different_account.quota_windows, [])
+        self.assertEqual(
+            [error.code for error in different_account.errors], ["NETWORK_ERROR"]
+        )
+
+    def test_legacy_codex_snapshot_does_not_restore_unverified_statistics(self):
+        class QuotaProvider(FakeProvider):
+            id = "codex"
+            name = "Codex"
+            supports_subscription_quota = True
+
+            def snapshot_identity(self):
+                return "same-account"
+
+        payload = {
+            "version": 2,
+            "windows": [
+                {
+                    "id": "codex-weekly",
+                    "title": "每周额度",
+                    "used_percent": 25,
+                }
+            ],
+            "statistics": [
+                {"title": "累计 Token 数", "value": "错误估算", "detail": "本机估算"}
+            ],
+            "activity": [["2026-07-02", 9999]],
+            "weekly_activity": [["2026-07-02", 9999]],
+        }
+        with patch.object(
+            history,
+            "load_provider_quota_snapshot",
+            return_value=(payload, datetime(2026, 7, 3, 10, 30)),
+        ):
+            restored = TokenData._load_persisted_quota_snapshot(QuotaProvider())
+
+        self.assertEqual(restored.quota_windows[0].used_percent, 25)
+        self.assertEqual(restored.quota_statistics, [])
+        self.assertEqual(restored.daily_usage, [])
+        self.assertEqual(restored.weekly_usage, [])
+
+    def test_legacy_codex_snapshot_restores_verified_interface_cache(self):
+        class QuotaProvider(FakeProvider):
+            id = "codex"
+            name = "Codex"
+            supports_subscription_quota = True
+
+            def snapshot_identity(self):
+                return "same-account"
+
+        today = date.today().isoformat()
+        yesterday = (date.today() - timedelta(days=1)).isoformat()
+        payload = {
+            "version": 2,
+            "statistics": [
+                {
+                    "title": "累计 Token 数",
+                    "value": "26.1亿",
+                    "detail": "来自 Codex 账号统计",
+                }
+            ],
+            "activity": [[yesterday, 1000], [today, 2000]],
+            "weekly_activity": [[yesterday, 1000], [today, 3000]],
+        }
+        with patch.object(
+            history,
+            "load_provider_quota_snapshot",
+            return_value=(payload, datetime.now()),
+        ):
+            restored = TokenData._load_persisted_quota_snapshot(QuotaProvider())
+
+        self.assertEqual(restored.quota_statistics[0].value, "26.1亿")
+        self.assertEqual(
+            {item["date"]: item["tokens"] for item in restored.daily_usage},
+            {yesterday: 1000},
+        )
+        self.assertEqual(
+            {item["date"]: item["tokens"] for item in restored.weekly_usage},
+            {yesterday: 1000, today: 3000},
+        )
+        self.assertEqual(restored.activity_source, "cache")
+        self.assertEqual(restored.statistics_source, "cache")
 
     def test_codex_network_failure_without_cached_quota_keeps_error_visible(self):
         class FailedQuotaProvider(FakeProvider):

--- a/ui/qt_panel.py
+++ b/ui/qt_panel.py
@@ -96,6 +96,15 @@ def format_token_axis(value: float) -> str:
     return compact_tokens(int(round(value)))
 
 
+def format_codex_tokens(value: int | float) -> str:
+    amount = int(round(value))
+    denominator, suffix = (
+        (100_000_000, "亿") if abs(amount) >= 100_000_000 else (10_000, "万")
+    )
+    text = f"{amount / denominator:.1f}".rstrip("0").rstrip(".")
+    return f"{text or '0'}{suffix}"
+
+
 def format_money_axis(value: float, currency: str = "CNY") -> str:
     absolute = abs(value)
     if absolute >= 100:
@@ -145,7 +154,7 @@ class MoneyAxis(pg.AxisItem):
 
     def tickStrings(self, values, scale, spacing):
         if self.token_mode:
-            return [format_token_axis(value * scale) for value in values]
+            return [format_codex_tokens(value * scale) for value in values]
         return [format_money_axis(value * scale, self.currency) for value in values]
 
 
@@ -1039,7 +1048,7 @@ class TrendCard(QFrame):
         if self._token_mode:
             return (
                 f"{self._dates[index].isoformat()}\n"
-                f"Token：{compact_tokens(int(self._values[index]))}"
+                f"Token：{format_codex_tokens(self._values[index])}"
             )
         return (
             f"{self._dates[index].isoformat()}\n"
@@ -1988,9 +1997,14 @@ class StatisticsCard(QFrame):
     def set_quota_data(self, data: TokenData) -> None:
         self.title.setText("Codex 使用统计")
         items = [(metric.title, metric.value, metric.detail) for metric in data.quota_statistics]
+        source_tooltip = {
+            "interface": "来自 Codex 账号统计",
+            "cache": "当前显示最近一次缓存的 Codex 账号统计",
+        }.get(data.statistics_source, "")
         for index, (name, value) in enumerate(zip(self._names, self._values)):
             if index < len(items):
                 title, text, tooltip = items[index]
+                tooltip = source_tooltip or tooltip
                 name.setText(title)
                 name.setToolTip(tooltip)
                 value.setText(text if len(text) <= 22 else f"{text[:21]}…")
@@ -2717,14 +2731,22 @@ class MainPanel(QFrame):
         self.activity.set_activity(data.daily_usage)
         source_days = [day for day in self.activity.days if day.has_source_data]
         total = sum(day.token_count for day in source_days)
+        provider_id = (
+            data.per_provider[0].provider_id if data.per_provider else ""
+        )
+        formatted_total = (
+            format_codex_tokens(total)
+            if provider_id == "codex"
+            else compact_tokens(total)
+        )
         if not source_days:
             summary = "暂无 Token 活动"
         else:
             first = min(day.date for day in source_days)
             summary = (
-                f"数据始于 {first.isoformat()} · 共 {compact_tokens(total)}"
+                f"数据始于 {first.isoformat()} · 共 {formatted_total}"
                 if first > self.activity.period.start
-                else f"过去 12 个月共使用 {compact_tokens(total)}"
+                else f"过去 12 个月共使用 {formatted_total}"
             )
         self._annual_activity_summary = summary
         self.activity_summary.setText(summary)
@@ -2803,8 +2825,21 @@ class MainPanel(QFrame):
                 card.set_values(value, detail, "")
                 card.value.setToolTip(detail)
                 card.detail.setVisible(bool(detail))
-            # Codex 没有账单金额口径；顶部右侧只展示本机近七天 Token 活动。
-            self.trend.set_rows(data.daily_usage, currency=self._currency, token_mode=True)
+            # 近 7 天拥有独立序列：只在这里合并本机当天估算，不能传给官方热力图。
+            self.trend.set_rows(
+                data.weekly_usage or data.daily_usage,
+                currency=self._currency,
+                token_mode=True,
+            )
+            weekly_tooltip = {
+                "interface": "来自 Codex 账号统计",
+                "mixed": "历史数据来自 Codex 账号统计；当天 Token 为本机会话日志估算",
+                "cache": "当前显示最近一次缓存的近 7 天数据",
+                "cache_mixed": "历史数据来自缓存；当天 Token 为本机会话日志估算",
+                "local": "接口统计暂不可用；仅当天 Token 来自本机会话日志估算",
+            }.get(data.weekly_activity_source, "")
+            self.trend.title.setToolTip(weekly_tooltip)
+            self.trend.plot.setToolTip(weekly_tooltip)
             self._activity_view = "annual"
             self.activity_stack.setCurrentIndex(0)
             self.annual_activity_button.setChecked(True)
@@ -2813,16 +2848,24 @@ class MainPanel(QFrame):
             for button in self.minute_legend_buttons.values():
                 button.hide()
             self.minute_estimate_label.hide()
-            self.activity_summary.setToolTip("根据本机 Codex 会话记录汇总，不上传会话内容")
+            activity_tooltip = {
+                "interface": "来自 Codex 账号统计，不含本机估算",
+                "cache": "当前显示最近一次缓存的官方 Token 活动",
+            }.get(data.activity_source, "暂无可用的官方 Token 活动")
+            self.activity_summary.setToolTip(activity_tooltip)
             self.activity_card.setFixedHeight(ANNUAL_ACTIVITY_SECTION_HEIGHT)
             self._set_annual_activity_data(data)
             self.statistics.set_quota_data(data)
             self.setFixedHeight(ANNUAL_PANEL_HEIGHT)
             self.activity_height_changed.emit(ANNUAL_PANEL_HEIGHT)
-            status, _color = self.status_summary(data, loading or refreshing)
+            # 已有缓存时后台刷新不应让状态栏长期停在“正在更新”；只有
+            # 首次加载无可展示数据时才使用加载态。
+            status = self.codex_source_summary(data, loading)
+            if not status:
+                status, _color = self.status_summary(data, loading or refreshing)
             self.status_text.setText(status)
-            self.status_dot.set_role(self.status_role(data, loading or refreshing))
-            self.updated_text.setText(self.relative_update_time(data))
+            self.status_dot.set_role(self.status_role(data, loading))
+            self.updated_text.setText(self.codex_update_time(data))
             return
 
         # API billing providers retain the original amount, trend and Token activity view.
@@ -2877,9 +2920,58 @@ class MainPanel(QFrame):
             return "warning"
         if data.status == "error":
             return "danger"
+        is_codex = bool(
+            data.per_provider and data.per_provider[0].provider_id == "codex"
+        )
+        if is_codex and data.quota_source and not all(
+            (
+                data.weekly_activity_source,
+                data.activity_source,
+                data.statistics_source,
+            )
+        ):
+            return "warning"
+        sources = (
+            data.quota_source,
+            data.weekly_activity_source,
+            data.activity_source,
+            data.statistics_source,
+        )
+        if data.is_stale or any(source.startswith("cache") for source in sources):
+            return "warning"
         if data.status == "ok":
             return "success"
         return "accent"
+
+    @staticmethod
+    def codex_source_summary(data: TokenData, loading: bool = False) -> str:
+        if data.errors or data.status in {"not_configured", "partial", "error"}:
+            return ""
+        entries = (
+            ("额度", data.quota_source),
+            ("近 7 天", data.weekly_activity_source),
+            ("热力图", data.activity_source),
+            ("底部统计", data.statistics_source),
+        )
+        labels_by_source: dict[str, list[str]] = {}
+        for label, source in entries:
+            labels_by_source.setdefault(source or "unavailable", []).append(label)
+        source_names = {
+            "interface": "接口数据",
+            "cache": "缓存数据",
+            "mixed": "接口 + 今日本机估算",
+            "cache_mixed": "缓存 + 今日本机估算",
+            "local": "今日本机估算",
+            "unavailable": "暂无数据",
+        }
+        parts = [
+            f"{'/'.join(labels)}：{source_names.get(source, source)}"
+            for source, labels in labels_by_source.items()
+        ]
+        if not parts:
+            return ""
+        summary = " · ".join(parts)
+        return f"正在更新 · 当前显示 {summary}" if loading else summary
 
     @staticmethod
     def status_summary(data: TokenData, loading: bool = False) -> tuple[str, str]:
@@ -2922,3 +3014,22 @@ class MainPanel(QFrame):
         if minutes < 60:
             return f"数据更新于 {minutes} 分钟前"
         return f"数据更新于 {minutes // 60} 小时前"
+
+    @staticmethod
+    def codex_update_time(data: TokenData) -> str:
+        text = MainPanel.relative_update_time(data)
+        if text == "等待首次更新":
+            return text
+        sources = {
+            data.quota_source,
+            data.weekly_activity_source,
+            data.activity_source,
+            data.statistics_source,
+        }
+        if sources <= {"", "cache", "cache_mixed"}:
+            return text.replace("数据更新于", "缓存保存于", 1)
+        if data.quota_source == "interface" and any(
+            source.startswith("cache") for source in sources
+        ):
+            return text.replace("数据更新于", "额度更新于", 1)
+        return text

--- a/ui/qt_widget.py
+++ b/ui/qt_widget.py
@@ -181,7 +181,10 @@ class FloatingWidget(QWidget):
         super().__init__()
         self.tray = tray_icon
         self._expanded = False
-        self._data = TokenData()
+        # 启动时先展示同一账号的落盘快照；网络刷新继续在后台按原频率进行。
+        self._data = (
+            TokenData.persisted_snapshot(config_manager.all_config()) or TokenData()
+        )
         self._refresh_lock = threading.Lock()
         self._refreshing = False
         self._request_id = 0


### PR DESCRIPTION
## 修改类型

- [ ] 功能新增
- [x] Bug 修复
- [x] 功能优化
- [ ] 代码重构
- [x] 文档更新

## 修改内容

- 改用 Codex 账号统计接口提供年度活动热力图和底部统计，避免本机会话口径与官方页面不一致。
- 将近 7 天图独立处理：历史数据采用接口结果，仅在接口缺少当天记录时使用本机会话日志估算，次日由官方数据替换。
- 将额度刷新与慢速统计刷新拆分，统计、近 7 天图和热力图复用 1 小时缓存，额度继续遵循用户配置的刷新间隔。
- 增加按匿名账号指纹隔离的 SQLite 快照，弱网、限流、服务异常以及离线重启时恢复最后一次成功的官方数据。
- 在面板中明确标注接口、缓存、接口加今日本机估算等数据来源，并避免有缓存时长期显示“正在更新”。
- 修正本地 JSONL 估算中重复累加 cached input token 的问题，并同步更新说明文档和测试。

## 根因

- 原实现的热力图与底部统计来自本机会话日志，统计范围和精度与 Codex 账号页不同。
- 慢速账号统计未与高频额度刷新隔离，弱网或辅助接口失败时容易反复请求并导致界面数据被清空或替换。
- 快照只存在于进程内存，程序退出后无法在网络异常时恢复最后成功数据。

## 用户影响

- Codex 面板的官方统计口径与账号页保持一致。
- 额度仍按原配置及时刷新，统计接口调用频率降低至每小时一次。
- 网络不佳时继续展示已标记的数据缓存，不再无提示地变成不准确的本地统计。

## 影响范围

- Codex Provider 额度与账号统计请求。
- TokenData 快照存储、跨重启缓存恢复及来源字段。
- Codex 主面板近 7 天图、活动热力图、底部统计和状态提示。
- README、V2 设计说明及对应自动化测试。

## 验证结果

- `.\.venv\Scripts\python.exe -m pytest -q`：349 passed，13 subtests passed。
- `.\.venv\Scripts\python.exe -m pyright`：0 errors，0 warnings。
- `git diff --check`：通过。

## 版本变化

本次为开发提交，当前版本保持 `v1.11.4`，未创建版本 Tag。
