### PR TITLE
fix: 避免服务商凭据失效重复通知

### DIFF
--- a/tests/test_refresh.py
+++ b/tests/test_refresh.py
@@ -43,7 +43,8 @@ def widget_stub():
     widget.tray = Mock()
     widget.open_settings = Mock()
     widget._sync_pricing_state = Mock()
-    widget._auth_error_signatures = {}
+    widget._auth_expired_providers = set()
+    widget._auth_notified_providers = set()
     widget._auth_expired_provider_id = None
     widget._mimo_renewal_task = None
     widget._mimo_renewal_attempted = False
@@ -374,12 +375,15 @@ class RefreshTests(unittest.TestCase):
 
     def test_auth_expired_shows_one_tray_notification_until_recovery(self):
         widget = widget_stub()
-        expired = TokenData(
+        balance_expired = TokenData(
             errors=[FetchError("AUTH_EXPIRED", "余额", "Cookie 已失效")]
         )
+        usage_expired = TokenData(
+            errors=[FetchError("AUTH_EXPIRED", "用量明细", "登录状态已失效")]
+        )
 
-        widget._notify_auth_expired(expired, "deepseek", is_current=True)
-        widget._notify_auth_expired(expired, "deepseek", is_current=True)
+        widget._notify_auth_expired(balance_expired, "deepseek", is_current=True)
+        widget._notify_auth_expired(usage_expired, "deepseek", is_current=True)
 
         self.assertEqual(widget.tray.showMessage.call_count, 1)
         title, message, icon, timeout = widget.tray.showMessage.call_args.args
@@ -390,8 +394,67 @@ class RefreshTests(unittest.TestCase):
         self.assertEqual(timeout, 10_000)
 
         widget._notify_auth_expired(TokenData(status="ok"), "deepseek", is_current=True)
-        widget._notify_auth_expired(expired, "deepseek", is_current=True)
+        widget._notify_auth_expired(balance_expired, "deepseek", is_current=True)
         self.assertEqual(widget.tray.showMessage.call_count, 2)
+
+    def test_auth_expired_suspends_only_that_provider_periodic_collection(self):
+        widget = widget_stub()
+        widget._auth_expired_providers.add("deepseek")
+
+        with patch("ui.qt_widget.config_manager.get", return_value="codex"):
+            self.assertFalse(
+                widget._start_provider_refresh(
+                    "deepseek",
+                    {"ACTIVE_PROVIDER": "codex"},
+                    lightweight=True,
+                    queue_if_busy=False,
+                    reason="periodic_background",
+                )
+            )
+            self.assertTrue(
+                widget._start_provider_refresh(
+                    "mimo",
+                    {"ACTIVE_PROVIDER": "codex"},
+                    lightweight=True,
+                    queue_if_busy=False,
+                    reason="periodic_background",
+                )
+            )
+
+        self.assertEqual(widget._thread_pool.start.call_count, 1)
+        self.assertEqual(widget._thread_pool.start.call_args.args[0].provider_id, "mimo")
+
+    def test_auth_expired_allows_manual_retry(self):
+        widget = widget_stub()
+        widget._auth_expired_providers.add("deepseek")
+
+        with patch("ui.qt_widget.config_manager.get", return_value="deepseek"):
+            started = widget._start_provider_refresh(
+                "deepseek",
+                {"ACTIVE_PROVIDER": "deepseek"},
+                lightweight=True,
+                queue_if_busy=False,
+                reason="manual",
+            )
+
+        self.assertTrue(started)
+        widget._thread_pool.start.assert_called_once()
+
+    @patch("ui.qt_widget.config_manager.load_config")
+    def test_config_save_reopens_auth_validation_for_all_providers(self, load_config):
+        widget = widget_stub()
+        widget._auth_expired_providers.update({"deepseek", "mimo"})
+        widget._auth_notified_providers.update({"deepseek", "mimo"})
+        widget._update_controller = Mock()
+        widget._reschedule_refresh = Mock()
+        widget.refresh = Mock()
+
+        widget._on_config_saved()
+
+        load_config.assert_called_once_with()
+        self.assertEqual(widget._auth_expired_providers, set())
+        self.assertEqual(widget._auth_notified_providers, set())
+        widget.refresh.assert_called_once_with()
 
     def test_mimo_auth_expired_starts_silent_renewal(self):
         widget = widget_stub()
@@ -419,6 +482,23 @@ class RefreshTests(unittest.TestCase):
         widget.tray.showMessage.assert_called_once()
         self.assertIn("不会自动打开浏览器", widget.tray.showMessage.call_args.args[1])
 
+    def test_background_mimo_auth_expired_still_renews_after_provider_switch(self):
+        widget = widget_stub()
+        balance_expired = TokenData(
+            errors=[FetchError("AUTH_EXPIRED", "MiMo 余额", "Cookie 已失效")]
+        )
+        usage_expired = TokenData(
+            errors=[FetchError("AUTH_EXPIRED", "MiMo 用量", "登录状态已失效")]
+        )
+
+        widget._notify_auth_expired(balance_expired, "mimo", is_current=False)
+        widget._notify_auth_expired(usage_expired, "mimo", is_current=True)
+
+        self.assertEqual(widget.tray.showMessage.call_count, 1)
+        task = widget._thread_pool.start.call_args.args[0]
+        self.assertIsInstance(task, MiMoRenewalTask)
+        self.assertTrue(widget._mimo_renewal_attempted)
+
     @patch("ui.qt_widget.config_manager.save_config")
     def test_successful_mimo_renewal_saves_only_cookie_credentials(self, save_config):
         widget = widget_stub()
@@ -444,7 +524,7 @@ class RefreshTests(unittest.TestCase):
             "api-platform_ph=ph; api-platform_serviceToken=token; api-platform_slh=slh; userId=1",
         )
         widget._refresh_mimo_after_renewal.assert_called_once_with()
-        self.assertNotIn("mimo", widget._auth_error_signatures)
+        self.assertNotIn("mimo", widget._auth_expired_providers)
         self.assertIsNone(widget._mimo_renewal_task)
 
     @patch("ui.qt_widget.config_manager.save_config", side_effect=OSError("failed"))
@@ -459,7 +539,8 @@ class RefreshTests(unittest.TestCase):
             )
 
         self.assertEqual(widget._auth_expired_provider_id, "mimo")
-        self.assertIn("mimo", widget._auth_error_signatures)
+        self.assertIn("mimo", widget._auth_expired_providers)
+        self.assertIn("mimo", widget._auth_notified_providers)
         self.assertEqual(widget.tray.showMessage.call_count, 1)
 
     @patch("ui.qt_widget.MiMoProvider.recover_verified_cookie_via_chrome")
@@ -509,7 +590,7 @@ class RefreshTests(unittest.TestCase):
 
         save_config.assert_not_called()
         widget._refresh_mimo_after_renewal.assert_called_once_with()
-        self.assertNotIn("mimo", widget._auth_error_signatures)
+        self.assertNotIn("mimo", widget._auth_expired_providers)
 
     def test_status_summary_distinguishes_configuration_and_request_errors(self):
         cases = (

--- a/ui/qt_widget.py
+++ b/ui/qt_widget.py
@@ -196,7 +196,8 @@ class FloatingWidget(QWidget):
         self._provider_last_started: dict[str, float] = {}
         self._provider_task_started: dict[str, float] = {}
         self._closed = False
-        self._auth_error_signatures: dict[str, tuple[str, str, str]] = {}
+        self._auth_expired_providers: set[str] = set()
+        self._auth_notified_providers: set[str] = set()
         self._auth_expired_provider_id: str | None = None
         self._mimo_renewal_task: MiMoRenewalTask | None = None
         self._mimo_renewal_attempted = False
@@ -950,6 +951,10 @@ class FloatingWidget(QWidget):
 
     def _on_config_saved(self) -> None:
         config_manager.load_config()
+        # 设置保存后允许所有失效 Provider 各验证一次；验证成功后恢复定时采集，
+        # 仍然失效则只重新进入一次通知周期。
+        self._auth_expired_providers.clear()
+        self._auth_notified_providers.clear()
         self._sync_pricing_state(notify_transition=False)
         self._update_controller.reload_cached_release()
         self._update_controller.schedule_startup_check()
@@ -1031,6 +1036,14 @@ class FloatingWidget(QWidget):
     ) -> bool:
         provider_id = provider_id.strip().lower()
         if not provider_id:
+            return False
+        if reason in {"periodic_current", "periodic_background"} and provider_id in (
+            self._auth_expired_providers
+        ):
+            config_manager.logger().debug(
+                "Provider collection skipped: provider=%s reason=auth_expired",
+                provider_id,
+            )
             return False
         captured_config = dict(config_snapshot)
         captured_config["ACTIVE_PROVIDER"] = provider_id
@@ -1159,17 +1172,17 @@ class FloatingWidget(QWidget):
             }
             codes = {error.code for error in result.errors}
             if result.status in {"ok", "partial"} and not codes & remote_failures:
-                # 只有该 Provider 实际恢复成功后才重新开放相同鉴权通知。
-                self._auth_error_signatures.pop(provider_id, None)
+                # 只有该 Provider 实际恢复成功后才解除熔断并重新开放通知。
+                self._auth_expired_providers.discard(provider_id)
+                self._auth_notified_providers.discard(provider_id)
                 if self._auth_expired_provider_id == provider_id:
                     self._auth_expired_provider_id = None
                 if provider_id == "mimo":
                     self._mimo_renewal_attempted = False
             return
-        signature = (auth_error.code, auth_error.source, auth_error.message)
-        if self._auth_error_signatures.get(provider_id) == signature:
-            return
-        self._auth_error_signatures[provider_id] = signature
+        # 同一失效周期以 Provider 为单位，不因余额、用量等错误来源或文案变化
+        # 重复通知；后续新增 Provider 只需沿用 AUTH_EXPIRED 错误码即可复用。
+        self._auth_expired_providers.add(provider_id)
         if provider_id == "mimo" and is_current:
             if getattr(self, "_mimo_renewal_task", None) is not None:
                 return
@@ -1179,10 +1192,13 @@ class FloatingWidget(QWidget):
             self._start_mimo_cookie_renewal()
             return
 
-        self._auth_expired_provider_id = provider_id
+        if provider_id in self._auth_notified_providers:
+            return
         tray = getattr(self, "tray", None)
         if tray is None:
             return
+        self._auth_notified_providers.add(provider_id)
+        self._auth_expired_provider_id = provider_id
         if provider_id == "mimo":
             message = (
                 f"{auth_error.message}\n请切换到小米 MiMo 或打开设置重新登录；"
@@ -1252,15 +1268,16 @@ class FloatingWidget(QWidget):
         self._show_mimo_renewal_failure(error_code)
 
     def _show_mimo_renewal_failure(self, error_code: str) -> None:
+        self._auth_expired_providers.add("mimo")
+        if "mimo" in self._auth_notified_providers:
+            return
         self._auth_expired_provider_id = "mimo"
-        self._auth_error_signatures.setdefault(
-            "mimo", ("AUTH_EXPIRED", "MiMo", "authentication expired")
-        )
         message = MiMoProvider.describe_acquire_error(
             RuntimeError(error_code or "ACQUIRE_UNEXPECTED")
         )
         tray = getattr(self, "tray", None)
         if tray is not None:
+            self._auth_notified_providers.add("mimo")
             tray.showMessage(
                 f"{APP_DISPLAY_NAME}：MiMo 自动续期失败",
                 f"{message}\n点击此通知可手动重新获取 Cookie。",


### PR DESCRIPTION
## 修改类型

- [x] Bug 修复
- [x] 功能优化

## 修改内容

- 按服务商维度记录 AUTH_EXPIRED 失效周期，避免错误来源或文案变化导致重复通知。
- 仅暂停失效服务商的定时采集，保留手动刷新、服务商切换和配置保存后的恢复验证。
- 保持 MiMo 自动续期，并允许后台已失效的 MiMo 在切换为当前服务商后继续续期。

## 影响范围

- Qt 多服务商刷新调度与托盘鉴权通知。
- 刷新调度回归测试。
- 不修改服务商接口、配置协议、数据库和版本号。

## 验证结果

- 29 个刷新定向测试通过。
- 全量 368 passed，13 subtests passed。
- compileall、Ruff、Pyright 和 git diff --check 通过。
- 未执行真实服务商 Cookie 过期运行验证。

## 版本变化

- 当前版本保持 1.12.0，本次不创建 Tag、不触发 Release。
