### PR TITLE
feat: 增加 NayutoAI 模型用量视图并优化 Codex 重置时间

### DIFF
--- a/api/providers/base.py
+++ b/api/providers/base.py
@@ -52,6 +52,7 @@ class ExactMinuteUsage:
     token_rows: tuple[dict[str, Any], ...] = ()
     cost_rows: tuple[dict[str, Any], ...] = ()
     complete_months: tuple[tuple[int, int], ...] = ()
+    model_rows: tuple[dict[str, Any], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -132,6 +133,7 @@ class Provider:
     supports_cost = False
     supports_estimated_minute_usage = False
     supports_exact_minute_usage = False
+    supports_model_usage = False
     supports_cookie_acquisition = False
     supports_browser_credential_acquisition = False
     supports_subscription_quota = False

--- a/api/providers/nayuto.py
+++ b/api/providers/nayuto.py
@@ -105,6 +105,7 @@ class NayutoProvider(Provider):
     supports_daily_usage = True
     supports_cost = True
     supports_exact_minute_usage = True
+    supports_model_usage = True
     supports_browser_credential_acquisition = True
     credential_acquisition_label = "Bearer"
     credential_acquisition_automatic = False
@@ -345,6 +346,7 @@ class NayutoProvider(Provider):
         ] = {}
         minute_tokens: dict[tuple[date, int, str], int] = {}
         minute_costs: dict[tuple[date, int], Decimal] = {}
+        minute_models: dict[tuple[date, int, str], dict[str, Any]] = {}
         usage_dates: set[date] = set()
         dirty_rows = 0
 
@@ -400,6 +402,19 @@ class NayutoProvider(Provider):
                 minute_tokens[row_key] = minute_tokens.get(row_key, 0) + amount
             cost_key = (usage_date, minute)
             minute_costs[cost_key] = minute_costs.get(cost_key, Decimal("0")) + actual_cost
+            minute_model = minute_models.setdefault(
+                (usage_date, minute, model),
+                {
+                    "cache_hit_tokens": 0,
+                    "cache_miss_tokens": 0,
+                    "output_tokens": 0,
+                    "cost_cny": Decimal("0"),
+                },
+            )
+            minute_model["cache_hit_tokens"] += input_hit
+            minute_model["cache_miss_tokens"] += input_miss
+            minute_model["output_tokens"] += output
+            minute_model["cost_cny"] += actual_cost
             usage_dates.add(usage_date)
 
         payloads: list[dict[str, Any]] = []
@@ -441,13 +456,26 @@ class NayutoProvider(Provider):
             }
             for (usage_date, minute), amount in sorted(minute_costs.items())
         )
+        model_rows = tuple(
+            {
+                "usage_date": usage_date,
+                "minute": minute,
+                "model": model,
+                "cache_hit_tokens": values["cache_hit_tokens"],
+                "cache_miss_tokens": values["cache_miss_tokens"],
+                "output_tokens": values["output_tokens"],
+                "cost_cny": values["cost_cny"],
+            }
+            for (usage_date, minute, model), values in sorted(minute_models.items())
+        )
         return (
             payloads,
             ExactMinuteUsage(
-                tuple(sorted(usage_dates)),
-                token_rows,
-                cost_rows,
-                tuple(sorted(requested_months)),
+                usage_dates=tuple(sorted(usage_dates)),
+                token_rows=token_rows,
+                cost_rows=cost_rows,
+                complete_months=tuple(sorted(requested_months)),
+                model_rows=model_rows,
             ),
             dirty_rows,
         )

--- a/data/history.py
+++ b/data/history.py
@@ -119,6 +119,20 @@ def _connect() -> Iterator[sqlite3.Connection]:
                 );
                 CREATE INDEX IF NOT EXISTS idx_minute_cost_usage_provider_date
                     ON minute_cost_usage(provider, usage_date);
+                CREATE TABLE IF NOT EXISTS minute_model_usage (
+                    provider TEXT NOT NULL,
+                    usage_date TEXT NOT NULL,
+                    minute_index INTEGER NOT NULL,
+                    model TEXT NOT NULL,
+                    cache_hit_tokens INTEGER NOT NULL DEFAULT 0,
+                    cache_miss_tokens INTEGER NOT NULL DEFAULT 0,
+                    output_tokens INTEGER NOT NULL DEFAULT 0,
+                    cost_cny TEXT NOT NULL DEFAULT '0',
+                    updated_at TEXT NOT NULL,
+                    PRIMARY KEY (provider, usage_date, minute_index, model)
+                );
+                CREATE INDEX IF NOT EXISTS idx_minute_model_usage_provider_date
+                    ON minute_model_usage(provider, usage_date);
                 CREATE TABLE IF NOT EXISTS minute_cost_snapshot (
                     provider TEXT NOT NULL,
                     usage_date TEXT NOT NULL,
@@ -536,6 +550,7 @@ def _delete_expired_minute_usage(
         "minute_usage",
         "minute_usage_snapshot",
         "minute_cost_usage",
+        "minute_model_usage",
         "minute_cost_snapshot",
     ):
         cursor = connection.execute(
@@ -676,6 +691,7 @@ def replace_exact_minute_usage(
     cost_rows: list[dict[str, Any]],
     current_day: date,
     retention_days: int = 3,
+    model_rows: list[dict[str, Any]] | None = None,
 ) -> str:
     """Atomically replace provider-authored minute rows for complete dates."""
 
@@ -715,6 +731,68 @@ def replace_exact_minute_usage(
         key = (date_text, minute)
         cost_totals[key] = cost_totals.get(key, Decimal("0")) + amount
 
+    model_totals: dict[tuple[str, int, str], dict[str, Any]] = {}
+    if model_rows is not None:
+        for row in model_rows:
+            raw_date = row.get("usage_date")
+            usage_date = (
+                raw_date if isinstance(raw_date, date) else date.fromisoformat(str(raw_date))
+            )
+            date_text = usage_date.isoformat()
+            minute = int(row.get("minute"))
+            model = str(row.get("model") or "unknown").strip() or "unknown"
+            hit = int(row.get("cache_hit_tokens", 0) or 0)
+            miss = int(row.get("cache_miss_tokens", 0) or 0)
+            output = int(row.get("output_tokens", 0) or 0)
+            cost = Decimal(str(row.get("cost_cny", "0")))
+            if (
+                date_text not in normalized_dates
+                or not 0 <= minute < 1440
+                or min(hit, miss, output) < 0
+                or not cost.is_finite()
+                or cost < 0
+            ):
+                raise ValueError("invalid exact minute model row")
+            values = model_totals.setdefault(
+                (date_text, minute, model),
+                {
+                    "cache_hit_tokens": 0,
+                    "cache_miss_tokens": 0,
+                    "output_tokens": 0,
+                    "cost_cny": Decimal("0"),
+                },
+            )
+            values["cache_hit_tokens"] += hit
+            values["cache_miss_tokens"] += miss
+            values["output_tokens"] += output
+            values["cost_cny"] += cost
+
+        model_token_totals: dict[tuple[str, int, str], int] = {}
+        model_cost_totals: dict[tuple[str, int], Decimal] = {}
+        for (usage_date, minute, _model), values in model_totals.items():
+            for token_type, field in (
+                ("PROMPT_CACHE_HIT_TOKEN", "cache_hit_tokens"),
+                ("PROMPT_CACHE_MISS_TOKEN", "cache_miss_tokens"),
+                ("RESPONSE_TOKEN", "output_tokens"),
+            ):
+                key = (usage_date, minute, token_type)
+                model_token_totals[key] = model_token_totals.get(key, 0) + int(
+                    values[field]
+                )
+            cost_key = (usage_date, minute)
+            model_cost_totals[cost_key] = model_cost_totals.get(
+                cost_key, Decimal("0")
+            ) + Decimal(values["cost_cny"])
+        if any(
+            token_totals.get(key, 0) != model_token_totals.get(key, 0)
+            for key in set(token_totals) | set(model_token_totals)
+        ) or any(
+            cost_totals.get(key, Decimal("0"))
+            != model_cost_totals.get(key, Decimal("0"))
+            for key in set(cost_totals) | set(model_cost_totals)
+        ):
+            raise ValueError("exact minute model totals do not match minute totals")
+
     updated_at = datetime.now().isoformat(timespec="seconds")
     with _connect() as connection:
         cleanup_threshold, deleted_rows = _delete_expired_minute_usage(
@@ -729,6 +807,11 @@ def replace_exact_minute_usage(
                 "DELETE FROM minute_cost_usage WHERE provider = ? AND usage_date = ?",
                 (provider, usage_date),
             )
+            if model_rows is not None:
+                connection.execute(
+                    "DELETE FROM minute_model_usage WHERE provider = ? AND usage_date = ?",
+                    (provider, usage_date),
+                )
             # Exact providers do not use delta baselines. Removing any old snapshot
             # prevents a future capability change from mixing the two semantics.
             connection.execute(
@@ -754,10 +837,29 @@ def replace_exact_minute_usage(
                      VALUES (?, ?, ?, ?, ?)""",
                 (provider, usage_date, minute, str(amount), updated_at),
             )
+        for (usage_date, minute, model), values in model_totals.items():
+            connection.execute(
+                """INSERT INTO minute_model_usage
+                       (provider, usage_date, minute_index, model,
+                        cache_hit_tokens, cache_miss_tokens, output_tokens,
+                        cost_cny, updated_at)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    provider,
+                    usage_date,
+                    minute,
+                    model,
+                    values["cache_hit_tokens"],
+                    values["cache_miss_tokens"],
+                    values["output_tokens"],
+                    str(values["cost_cny"]),
+                    updated_at,
+                ),
+            )
     _log_minute_usage_cleanup(
         provider, retention_days, cleanup_threshold, deleted_rows
     )
-    return "recorded" if token_totals or cost_totals else "empty"
+    return "recorded" if token_totals or cost_totals or model_totals else "empty"
 
 
 def minute_usage_for_day(provider: str, usage_day: date) -> list[dict[str, Any]]:
@@ -805,6 +907,39 @@ def minute_cost_usage_for_day(provider: str, usage_day: date) -> list[dict[str, 
     return result
 
 
+def minute_model_usage_for_day(provider: str, usage_day: date) -> list[dict[str, Any]]:
+    """读取指定日期按分钟和模型保存的服务商原始明细。"""
+    result: list[dict[str, Any]] = []
+    with _connect() as connection:
+        rows = connection.execute(
+            """SELECT minute_index, model, cache_hit_tokens, cache_miss_tokens,
+                      output_tokens, cost_cny
+                 FROM minute_model_usage
+                WHERE provider = ? AND usage_date = ?
+                ORDER BY minute_index, model""",
+            (provider, usage_day.isoformat()),
+        )
+        for minute, model, hit, miss, output, raw_cost in rows:
+            try:
+                cost = Decimal(str(raw_cost or "0"))
+            except (InvalidOperation, ValueError):
+                config_manager.logger().warning("Skipped malformed cached minute model cost")
+                continue
+            if not cost.is_finite():
+                continue
+            result.append(
+                {
+                    "minute": int(minute),
+                    "model": str(model or "unknown"),
+                    "cache_hit_tokens": int(hit or 0),
+                    "cache_miss_tokens": int(miss or 0),
+                    "output_tokens": int(output or 0),
+                    "cost_cny": cost,
+                }
+            )
+    return result
+
+
 def minute_usage_dates(provider: str) -> list[str]:
     """读取指定提供商仍保留分时缓存的日期，按日期升序返回。"""
     with _connect() as connection:
@@ -817,10 +952,12 @@ def minute_usage_dates(provider: str) -> list[str]:
                      UNION
                      SELECT usage_date FROM minute_cost_usage WHERE provider = ?
                      UNION
+                     SELECT usage_date FROM minute_model_usage WHERE provider = ?
+                     UNION
                      SELECT usage_date FROM minute_cost_snapshot WHERE provider = ?
                  )
                  ORDER BY usage_date""",
-            (provider, provider, provider, provider),
+            (provider, provider, provider, provider, provider),
         ).fetchall()
     return [str(usage_date) for (usage_date,) in rows]
 
@@ -864,6 +1001,66 @@ def recent_daily(days: int = 371, provider: str | None = None) -> list[dict[str,
             except (InvalidOperation, ValueError):
                 config_manager.logger().warning("Skipped malformed cached daily cost")
     return list(daily.values())
+
+
+def recent_daily_model_usage(
+    provider: str, current_day: date, days: int = 7
+) -> list[dict[str, Any]]:
+    """读取连续自然日内的按模型 Token 构成和十进制金额。"""
+    day_count = max(1, int(days))
+    start = current_day - timedelta(days=day_count - 1)
+    ordered_days = [start + timedelta(days=offset) for offset in range(day_count)]
+    by_day: dict[str, dict[str, dict[str, Any]]] = {
+        usage_day.isoformat(): {} for usage_day in ordered_days
+    }
+    with _connect() as connection:
+        rows = connection.execute(
+            """SELECT usage_date, model, token_type, token_amount, cost_cny
+                 FROM daily_usage
+                WHERE provider = ? AND usage_date BETWEEN ? AND ?
+                ORDER BY usage_date, model, token_type""",
+            (provider, start.isoformat(), current_day.isoformat()),
+        )
+        for usage_date, raw_model, token_type, token_amount, raw_cost in rows:
+            model = str(raw_model or "unknown")
+            values = by_day[str(usage_date)].setdefault(
+                model,
+                {
+                    "date": str(usage_date),
+                    "model": model,
+                    "cache_hit_tokens": 0,
+                    "cache_miss_tokens": 0,
+                    "output_tokens": 0,
+                    "total_tokens": 0,
+                    "cost_cny": Decimal("0"),
+                },
+            )
+            field = {
+                "PROMPT_CACHE_HIT_TOKEN": "cache_hit_tokens",
+                "PROMPT_CACHE_MISS_TOKEN": "cache_miss_tokens",
+                "RESPONSE_TOKEN": "output_tokens",
+            }.get(str(token_type))
+            if field:
+                amount = int(token_amount or 0)
+                values[field] += amount
+                values["total_tokens"] += amount
+            if str(token_type) == "cost_cny":
+                try:
+                    values["cost_cny"] += Decimal(str(raw_cost or "0"))
+                except (InvalidOperation, ValueError):
+                    config_manager.logger().warning(
+                        "Skipped malformed cached daily model cost"
+                    )
+    return [
+        {
+            "date": usage_day.isoformat(),
+            "models": [
+                by_day[usage_day.isoformat()][model]
+                for model in sorted(by_day[usage_day.isoformat()])
+            ],
+        }
+        for usage_day in ordered_days
+    ]
 
 
 def provider_daily_payloads(provider: str, start: date, end: date) -> list[dict[str, Any]]:

--- a/data/store.py
+++ b/data/store.py
@@ -267,11 +267,11 @@ def cost_breakdown_for_day(
 
 def provider_observed_at(provider_id: str, observed_at: datetime) -> datetime:
     """将刷新时刻转换为提供商估算日界所使用的时区。"""
-    if provider_id == "mimo":
+    if provider_id in {"mimo", "nayuto"}:
         try:
             return observed_at.astimezone(ZoneInfo("Asia/Shanghai"))
         except ZoneInfoNotFoundError:
-            # Windows 打包环境可能没有 IANA 时区数据库；MiMo 的平台日界固定为 UTC+8。
+            # Windows 打包环境可能没有 IANA 时区数据库；这两个平台日界固定为 UTC+8。
             return observed_at.astimezone(timezone(timedelta(hours=8), "Asia/Shanghai"))
     # DeepSeek 未返回账单时区；按已确认的产品约定使用运行设备本地时区。
     return observed_at.astimezone()
@@ -283,11 +283,13 @@ def provider_usage_day(provider_id: str, observed_at: datetime) -> date:
 
 
 def _load_minute_history(
-    provider_id: str, current_day: date
+    provider_id: str, current_day: date, include_models: bool = False
 ) -> tuple[
     list[dict[str, Any]],
     list[dict[str, Any]],
+    list[dict[str, Any]],
     list[str],
+    dict[str, list[dict[str, Any]]],
     dict[str, list[dict[str, Any]]],
     dict[str, list[dict[str, Any]]],
 ]:
@@ -295,9 +297,15 @@ def _load_minute_history(
     current_key = current_day.isoformat()
     minute_rows = history.minute_usage_for_day(provider_id, current_day)
     minute_cost_rows = history.minute_cost_usage_for_day(provider_id, current_day)
+    minute_model_rows = (
+        history.minute_model_usage_for_day(provider_id, current_day)
+        if include_models
+        else []
+    )
     minute_days = history.minute_usage_dates(provider_id)
     minute_history: dict[str, list[dict[str, Any]]] = {}
     minute_cost_history: dict[str, list[dict[str, Any]]] = {}
+    minute_model_history: dict[str, list[dict[str, Any]]] = {}
     for usage_date in minute_days:
         usage_day = date.fromisoformat(usage_date)
         # 当前日已单独读取供悬浮面板使用；历史映射复用同一只读列表，
@@ -312,12 +320,23 @@ def _load_minute_history(
             if usage_date == current_key
             else history.minute_cost_usage_for_day(provider_id, usage_day)
         )
+        minute_model_history[usage_date] = (
+            (
+                minute_model_rows
+                if usage_date == current_key
+                else history.minute_model_usage_for_day(provider_id, usage_day)
+            )
+            if include_models
+            else []
+        )
     return (
         minute_rows,
         minute_cost_rows,
+        minute_model_rows,
         minute_days,
         minute_history,
         minute_cost_history,
+        minute_model_history,
     )
 
 
@@ -384,6 +403,7 @@ class TokenData:
     is_stale: bool = False
     last_updated: str = ""
     daily_usage: list[dict[str, Any]] = field(default_factory=list)
+    daily_model_usage: list[dict[str, Any]] = field(default_factory=list)
     weekly_usage: list[dict[str, Any]] = field(default_factory=list)
     minute_usage: list[dict[str, Any]] = field(default_factory=list)
     minute_usage_status: str = "unavailable"
@@ -392,6 +412,8 @@ class TokenData:
     minute_usage_history: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
     minute_cost_usage: list[dict[str, Any]] = field(default_factory=list)
     minute_cost_usage_history: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    minute_model_usage: list[dict[str, Any]] = field(default_factory=list)
+    minute_model_usage_history: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
     minute_usage_source: str = ""
 
     _last_snapshot: ClassVar["TokenData | None"] = None
@@ -408,6 +430,8 @@ class TokenData:
             id(snapshot.minute_usage_history): {},
             id(snapshot.minute_cost_usage): [],
             id(snapshot.minute_cost_usage_history): {},
+            id(snapshot.minute_model_usage): [],
+            id(snapshot.minute_model_usage_history): {},
         }
         return copy.deepcopy(snapshot, memo)
 
@@ -418,12 +442,15 @@ class TokenData:
         memo = {
             id(data.minute_usage): data.minute_usage,
             id(data.minute_cost_usage): data.minute_cost_usage,
+            id(data.minute_model_usage): data.minute_model_usage,
         }
         # 外层映射仍由 deepcopy 隔离，只有已完成的行列表共享，避免调用方
         # 增删日期时改变缓存，同时把主要内存占用限制为单份。
         for rows in data.minute_usage_history.values():
             memo[id(rows)] = rows
         for rows in data.minute_cost_usage_history.values():
+            memo[id(rows)] = rows
+        for rows in data.minute_model_usage_history.values():
             memo[id(rows)] = rows
         return copy.deepcopy(data, memo)
 
@@ -844,10 +871,12 @@ class TokenData:
         quota_refresh_succeeded = False
         minute_rows: list[dict[str, Any]] = []
         minute_cost_rows: list[dict[str, Any]] = []
+        minute_model_rows: list[dict[str, Any]] = []
         minute_status = "unavailable"
         minute_days: list[str] = []
         minute_history: dict[str, list[dict[str, Any]]] = {}
         minute_cost_history: dict[str, list[dict[str, Any]]] = {}
+        minute_model_history: dict[str, list[dict[str, Any]]] = {}
         retention_days = 3
         supports_estimated_minutes = bool(
             getattr(provider, "supports_estimated_minute_usage", False)
@@ -855,6 +884,7 @@ class TokenData:
         supports_exact_minutes = bool(
             getattr(provider, "supports_exact_minute_usage", False)
         )
+        supports_model_usage = bool(getattr(provider, "supports_model_usage", False))
         supports_minute_usage = supports_estimated_minutes or supports_exact_minutes
         if supports_minute_usage:
             try:
@@ -879,6 +909,7 @@ class TokenData:
             )
             per.errors.append(FetchError("NOT_CONFIGURED", provider.name, f"尚未配置 {provider.name} 凭据"))
             data.daily_usage = []
+            data.daily_model_usage = []
             data.weekly_usage = []
             data.last_success_at = None
             data.last_updated = ""
@@ -1155,20 +1186,29 @@ class TokenData:
                         exact_dates.add(current_day)
                         try:
                             minute_status = history.replace_exact_minute_usage(
-                                provider.id,
-                                exact_dates,
-                                [
+                                provider=provider.id,
+                                usage_dates=exact_dates,
+                                token_rows=[
                                     row
                                     for row in exact_usage.token_rows
                                     if row.get("usage_date") in exact_dates
                                 ],
-                                [
+                                cost_rows=[
                                     row
                                     for row in exact_usage.cost_rows
                                     if row.get("usage_date") in exact_dates
                                 ],
-                                current_day,
-                                retention_days,
+                                current_day=current_day,
+                                retention_days=retention_days,
+                                model_rows=(
+                                    [
+                                        row
+                                        for row in exact_usage.model_rows
+                                        if row.get("usage_date") in exact_dates
+                                    ]
+                                    if supports_model_usage
+                                    else None
+                                ),
                             )
                         except Exception:
                             config_manager.logger().exception(
@@ -1213,6 +1253,12 @@ class TokenData:
             try:
                 if provider.supports_daily_usage:
                     data.daily_usage = history.recent_daily(371, provider.id)
+                if supports_model_usage:
+                    data.daily_model_usage = history.recent_daily_model_usage(
+                        provider.id, current_day, 7
+                    )
+                else:
+                    data.daily_model_usage = []
                 if provider.supports_cost and per.total_cost_cny is None:
                     per.total_cost_cny = float(history.total_cost(provider.id))
             except Exception:
@@ -1233,10 +1279,14 @@ class TokenData:
                 (
                     minute_rows,
                     minute_cost_rows,
+                    minute_model_rows,
                     minute_days,
                     minute_history,
                     minute_cost_history,
-                ) = _load_minute_history(provider.id, current_day)
+                    minute_model_history,
+                ) = _load_minute_history(
+                    provider.id, current_day, include_models=supports_model_usage
+                )
             except Exception:
                 config_manager.logger().exception(
                     "Minute usage history read failed for %s", provider.id
@@ -1281,6 +1331,8 @@ class TokenData:
         data.minute_usage_history = minute_history
         data.minute_cost_usage = minute_cost_rows
         data.minute_cost_usage_history = minute_cost_history
+        data.minute_model_usage = minute_model_rows
+        data.minute_model_usage_history = minute_model_history
         data.minute_usage_source = (
             "provider" if supports_exact_minutes else "estimated"
             if supports_estimated_minutes

--- a/tests/test_nayuto.py
+++ b/tests/test_nayuto.py
@@ -13,7 +13,7 @@ import pytest
 import requests
 
 from api import browser_cookie
-from api.providers.base import FetchError, ProviderBalance, ProviderSummary
+from api.providers.base import ExactMinuteUsage, FetchError, ProviderBalance, ProviderSummary
 from api.providers.nayuto import NayutoProvider
 from config.defaults import SECRET_KEYS
 from config.store import public_values
@@ -94,6 +94,26 @@ def test_real_shape_maps_tokens_actual_cost_and_utc_to_shanghai():
         for row in exact.cost_rows
         if row["usage_date"] == date(2026, 8, 15) and row["minute"] == 0
     ) == Decimal("0.0303")
+    assert exact.model_rows == (
+        {
+            "usage_date": date(2026, 8, 15),
+            "minute": 0,
+            "model": "gpt-fixture",
+            "cache_hit_tokens": 14,
+            "cache_miss_tokens": 9,
+            "output_tokens": 18,
+            "cost_cny": Decimal("0.0303"),
+        },
+        {
+            "usage_date": date(2026, 8, 16),
+            "minute": 0,
+            "model": "gpt-fixture",
+            "cache_hit_tokens": 23,
+            "cache_miss_tokens": 17,
+            "output_tokens": 19,
+            "cost_cny": Decimal("0.0303"),
+        },
+    )
     # The fixture's failed row is included because billing semantics are not proven.
     assert first_minute_tokens["PROMPT_CACHE_MISS_TOKEN"] == 2 + 7
 
@@ -146,6 +166,41 @@ def test_request_id_then_real_id_then_stable_fallback_deduplicate():
     totals = usage_totals(payloads, "2026-08-15")
     assert totals["PROMPT_CACHE_MISS_TOKEN"] == 9
     assert len(exact.cost_rows) == 2
+
+
+def test_minute_models_aggregate_same_model_and_keep_multiple_models_and_unknown():
+    source = usage_fixture()["items"][0]
+    first = copy.deepcopy(source)
+    first["request_id"] = "model-a-1"
+    first["model"] = "model-a"
+    second = copy.deepcopy(source)
+    second["request_id"] = "model-a-2"
+    second["model"] = "model-a"
+    third = copy.deepcopy(source)
+    third["request_id"] = "model-b"
+    third["model"] = "model-b"
+    unknown = copy.deepcopy(source)
+    unknown["request_id"] = "model-missing"
+    unknown.pop("model")
+
+    _payloads, exact, dirty = NayutoProvider._normalize_records(
+        [first, second, third, unknown], {(8, 2026)}
+    )
+
+    assert dirty == 0
+    rows = {row["model"]: row for row in exact.model_rows}
+    assert list(rows) == ["model-a", "model-b", "unknown"]
+    assert rows["model-a"]["cache_hit_tokens"] == 6
+    assert rows["model-a"]["cache_miss_tokens"] == 4
+    assert rows["model-a"]["output_tokens"] == 10
+    assert rows["model-a"]["cost_cny"] == Decimal("0.0202")
+    assert rows["model-b"]["cost_cny"] == Decimal("0.0101")
+    assert rows["unknown"]["output_tokens"] == 5
+
+
+def test_exact_minute_usage_positional_fields_remain_compatible():
+    exact = ExactMinuteUsage((date(2026, 8, 15),), (), (), ((8, 2026),))
+    assert exact.model_rows == ()
 
 
 def test_dirty_core_fields_are_skipped_without_losing_valid_rows():
@@ -353,9 +408,35 @@ def test_exact_minute_replace_is_decimal_and_idempotent():
             {"usage_date": usage_day, "minute": 601, "cost_cny": Decimal("0.1")},
             {"usage_date": usage_day, "minute": 601, "cost_cny": Decimal("0.2")},
         ]
+        model_rows = [
+            {
+                "usage_date": usage_day,
+                "minute": 601,
+                "model": "model-a",
+                "cache_hit_tokens": 3,
+                "cache_miss_tokens": 0,
+                "output_tokens": 0,
+                "cost_cny": Decimal("0.1"),
+            },
+            {
+                "usage_date": usage_day,
+                "minute": 601,
+                "model": "model-b",
+                "cache_hit_tokens": 4,
+                "cache_miss_tokens": 0,
+                "output_tokens": 0,
+                "cost_cny": Decimal("0.2"),
+            },
+        ]
         for _ in range(2):
             assert history.replace_exact_minute_usage(
-                "nayuto", {usage_day}, token_rows, cost_rows, usage_day, 3
+                "nayuto",
+                {usage_day},
+                token_rows,
+                cost_rows,
+                usage_day,
+                3,
+                model_rows=model_rows,
             ) == "recorded"
         assert history.minute_usage_for_day("nayuto", usage_day) == [
             {
@@ -367,10 +448,161 @@ def test_exact_minute_replace_is_decimal_and_idempotent():
         assert history.minute_cost_usage_for_day("nayuto", usage_day) == [
             {"minute": 601, "cost_cny": Decimal("0.3")}
         ]
+        assert history.minute_model_usage_for_day("nayuto", usage_day) == [
+            {
+                "minute": 601,
+                "model": "model-a",
+                "cache_hit_tokens": 3,
+                "cache_miss_tokens": 0,
+                "output_tokens": 0,
+                "cost_cny": Decimal("0.1"),
+            },
+            {
+                "minute": 601,
+                "model": "model-b",
+                "cache_hit_tokens": 4,
+                "cache_miss_tokens": 0,
+                "output_tokens": 0,
+                "cost_cny": Decimal("0.2"),
+            },
+        ]
 
-        history.replace_exact_minute_usage("nayuto", {usage_day}, [], [], usage_day, 3)
+        history.replace_exact_minute_usage(
+            "nayuto", {usage_day}, [], [], usage_day, 3, model_rows=[]
+        )
         assert history.minute_usage_for_day("nayuto", usage_day) == []
         assert history.minute_cost_usage_for_day("nayuto", usage_day) == []
+        assert history.minute_model_usage_for_day("nayuto", usage_day) == []
+
+
+def test_daily_model_usage_is_seven_days_cross_month_and_keeps_decimal_cost():
+    payload = {
+        "days": [
+            {
+                "date": "2026-07-31",
+                "data": [
+                    {
+                        "model": "model-b",
+                        "usage": [
+                            {"type": "PROMPT_CACHE_HIT_TOKEN", "amount": 4},
+                            {"type": "PROMPT_CACHE_MISS_TOKEN", "amount": 3},
+                            {"type": "RESPONSE_TOKEN", "amount": 2},
+                            {"type": "cost_cny", "amount": "0.1001"},
+                        ],
+                    },
+                    {
+                        "model": "model-a",
+                        "usage": [
+                            {"type": "PROMPT_CACHE_HIT_TOKEN", "amount": 1},
+                            {"type": "PROMPT_CACHE_MISS_TOKEN", "amount": 2},
+                            {"type": "RESPONSE_TOKEN", "amount": 3},
+                            {"type": "cost_cny", "amount": "0.2002"},
+                        ],
+                    },
+                ],
+            },
+            {
+                "date": "2026-08-01",
+                "data": [
+                    {
+                        "model": "model-a",
+                        "usage": [
+                            {"type": "RESPONSE_TOKEN", "amount": 5},
+                            {"type": "cost_cny", "amount": "0.3003"},
+                        ],
+                    }
+                ],
+            },
+        ]
+    }
+    with tempfile.TemporaryDirectory() as temp_dir, patch.object(
+        history, "DB_PATH", Path(temp_dir) / "usage.db"
+    ):
+        history.save_usage([payload], [payload], provider="nayuto")
+        rows = history.recent_daily_model_usage("nayuto", date(2026, 8, 2), 7)
+
+    assert len(rows) == 7
+    assert rows[0]["date"] == "2026-07-27"
+    assert rows[-1]["date"] == "2026-08-02"
+    july = next(row for row in rows if row["date"] == "2026-07-31")
+    assert [item["model"] for item in july["models"]] == ["model-a", "model-b"]
+    assert july["models"][0] == {
+        "date": "2026-07-31",
+        "model": "model-a",
+        "cache_hit_tokens": 1,
+        "cache_miss_tokens": 2,
+        "output_tokens": 3,
+        "total_tokens": 6,
+        "cost_cny": Decimal("0.2002"),
+    }
+    august = next(row for row in rows if row["date"] == "2026-08-01")
+    assert august["models"][0]["cost_cny"] == Decimal("0.3003")
+
+
+def test_minute_models_are_atomic_provider_isolated_and_cleaned_with_retention():
+    usage_day = date(2026, 8, 15)
+    old_day = date(2026, 8, 12)
+    token_rows = [
+        {
+            "usage_date": usage_day,
+            "minute": 10,
+            "token_type": "RESPONSE_TOKEN",
+            "token_amount": 5,
+        }
+    ]
+    cost_rows = [{"usage_date": usage_day, "minute": 10, "cost_cny": "0.5"}]
+    model_rows = [
+        {
+            "usage_date": usage_day,
+            "minute": 10,
+            "model": "model-a",
+            "cache_hit_tokens": 0,
+            "cache_miss_tokens": 0,
+            "output_tokens": 5,
+            "cost_cny": "0.5",
+        }
+    ]
+    with tempfile.TemporaryDirectory() as temp_dir, patch.object(
+        history, "DB_PATH", Path(temp_dir) / "usage.db"
+    ):
+        for provider in ("nayuto", "other"):
+            history.replace_exact_minute_usage(
+                provider,
+                {usage_day},
+                token_rows,
+                cost_rows,
+                usage_day,
+                model_rows=model_rows,
+            )
+        with pytest.raises(ValueError, match="do not match"):
+            history.replace_exact_minute_usage(
+                "nayuto",
+                {usage_day},
+                token_rows,
+                cost_rows,
+                usage_day,
+                model_rows=[{**model_rows[0], "output_tokens": 4}],
+            )
+        assert history.minute_model_usage_for_day("nayuto", usage_day)[0][
+            "output_tokens"
+        ] == 5
+
+        history.replace_exact_minute_usage(
+            "nayuto",
+            {old_day},
+            [{**token_rows[0], "usage_date": old_day}],
+            [{**cost_rows[0], "usage_date": old_day}],
+            usage_day,
+            model_rows=[{**model_rows[0], "usage_date": old_day}],
+        )
+        history.clear_expired_minute_usage("nayuto", usage_day, retention_days=1)
+        assert history.minute_model_usage_for_day("nayuto", old_day) == []
+        assert history.minute_model_usage_for_day("other", usage_day)
+        history.replace_exact_minute_usage(
+            "nayuto", {usage_day}, [], [], usage_day, model_rows=[]
+        )
+        assert history.minute_model_usage_for_day("nayuto", usage_day) == []
+        assert history.minute_model_usage_for_day("other", usage_day)
 
 
 def test_store_uses_exact_minutes_and_preserves_them_on_fetch_failures():
@@ -422,6 +654,18 @@ def test_store_uses_exact_minutes_and_preserves_them_on_fetch_failures():
             assert first.minute_cost_usage == [
                 {"minute": 0, "cost_cny": Decimal("0.0303")}
             ]
+            assert first.minute_model_usage == [
+                {
+                    "minute": 0,
+                    "model": "gpt-fixture",
+                    "cache_hit_tokens": 14,
+                    "cache_miss_tokens": 9,
+                    "output_tokens": 18,
+                    "cost_cny": Decimal("0.0303"),
+                }
+            ]
+            assert len(first.daily_model_usage) == 7
+            assert first.daily_model_usage[-1]["models"][0]["model"] == "gpt-fixture"
             assert history.minute_usage_for_day("nayuto", stale_day) == []
 
             second = TokenData._fetch_with_provider(provider, date(2026, 8, 15))
@@ -448,6 +692,8 @@ def test_store_uses_exact_minutes_and_preserves_them_on_fetch_failures():
                 assert failed.today_tokens == 41
                 assert failed.minute_usage == first.minute_usage
                 assert failed.minute_cost_usage == first.minute_cost_usage
+                assert failed.minute_model_usage == first.minute_model_usage
+                assert failed.daily_model_usage == first.daily_model_usage
     finally:
         provider.close()
         TokenData._provider_snapshots = previous_snapshots

--- a/tests/test_qt_ui.py
+++ b/tests/test_qt_ui.py
@@ -49,6 +49,7 @@ from ui.qt_panel import (
     MinuteUsageChart,
     StatisticsCard,
     TrendCard,
+    format_codex_reset_time,
     format_codex_tokens,
     format_money,
     format_money_axis,
@@ -387,7 +388,7 @@ def test_money_format_uses_provider_native_currency():
 def test_panel_quick_switches_provider_and_renders_subscription_quota():
     panel = MainPanel()
     data = sample_data()
-    reset = datetime.now(timezone.utc) + timedelta(hours=2)
+    reset = datetime(2026, 8, 20, 3, 58, tzinfo=timezone.utc)
     data.quota_windows = [
         QuotaWindow("codex-weekly", "每周额度", 25, resets_at=reset),
     ]
@@ -447,7 +448,7 @@ def test_panel_quick_switches_provider_and_renders_subscription_quota():
     assert panel.today_card.value.text() == "已用 25%"
     assert not panel.today_card.detail.isHidden()
     assert "剩余 75%" in panel.today_card.detail.text()
-    assert "后重置" in panel.today_card.detail.text()
+    assert "8月20日 11:58重置" in panel.today_card.detail.text()
     assert panel.balance_card.title_label.text() == "可用 Credits"
     assert panel.balance_card.value.text() == "12.5"
     assert panel.month_card.title_label.text() == "订阅套餐"
@@ -761,6 +762,14 @@ def test_reset_countdown_is_timezone_safe_and_readable():
     assert format_reset_countdown(now + timedelta(minutes=45), now) == "45 分钟后重置"
 
 
+def test_codex_reset_time_uses_shanghai_month_day_hour_and_minute():
+    reset = datetime(2026, 8, 20, 3, 58, tzinfo=timezone.utc)
+
+    assert format_codex_reset_time(reset) == "8月20日 11:58重置"
+    assert format_codex_reset_time(reset, compact=True) == "8月20日11:58"
+    assert format_codex_reset_time(None) == "重置时间未知"
+
+
 def test_codex_ball_never_falls_back_to_currency_when_quota_is_unavailable():
     data = TokenData(
         status="partial",
@@ -782,7 +791,7 @@ def test_codex_ball_never_falls_back_to_currency_when_quota_is_unavailable():
 
 
 def test_codex_ball_uses_remaining_quota_and_compact_reset_time():
-    reset = datetime.now(timezone.utc) + timedelta(days=2, hours=8)
+    reset = datetime(2026, 8, 20, 3, 58, tzinfo=timezone.utc)
     window = QuotaWindow("codex-weekly", "每周额度", 25, resets_at=reset)
     data = TokenData(
         status="ok",
@@ -800,8 +809,7 @@ def test_codex_ball_uses_remaining_quota_and_compact_reset_time():
     assert widget.ball._quota_mode
     assert widget.ball._quota_remaining == 75
     assert widget.ball._quota_title == "周额度"
-    assert "天" in widget.ball._quota_reset_text
-    assert "小时后重置" in widget.ball._quota_reset_text
+    assert widget.ball._quota_reset_text == "8月20日11:58"
     assert widget.ball.accessibleDescription() == "75%"
 
     widget._data = sample_data()

--- a/tests/test_qt_ui.py
+++ b/tests/test_qt_ui.py
@@ -148,6 +148,9 @@ def test_trend_uses_exactly_seven_cost_bars_with_hover_tooltip():
     APP.processEvents()
 
     assert trend.title.text() == "近 7 天使用金额"
+    assert trend.amount_button.text() == "金额趋势"
+    assert trend.model_button.text() == "模型使用"
+    assert trend.amount_button.width() == trend.model_button.width()
     assert trend._values == [0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0]
     bar_items = [
         item
@@ -165,14 +168,155 @@ def test_trend_uses_exactly_seven_cost_bars_with_hover_tooltip():
     assert "使用金额：¥0.60" in trend.tooltip_text(0)
 
     scene_point = trend.plot.getViewBox().mapViewToScene(QPointF(0, 0.3))
-    with patch("ui.qt_panel.QToolTip.showText") as show_tooltip:
-        trend._on_mouse_moved((scene_point,))
+    trend._on_mouse_moved((scene_point,))
 
     assert trend._hover_index == 0
     assert len(trend._series.opts["brushes"]) == 7
-    assert show_tooltip.call_count == 1
-    assert show_tooltip.call_args.args[1] == trend.tooltip_text(0)
+    assert trend.hover_tooltip.isVisible()
+    assert trend.hover_tooltip.date_label.text() == (date.today() - timedelta(days=6)).isoformat()
+    assert trend.plot.toolTip() == ""
     trend.close()
+
+
+def test_nayuto_trend_groups_all_models_with_stable_order_colors_and_tooltip():
+    current = date(2026, 8, 15)
+    model_rows = [
+        {
+            "date": (current - timedelta(days=offset)).isoformat(),
+            "models": [
+                {
+                    "model": "model-b",
+                    "cache_hit_tokens": 2,
+                    "cache_miss_tokens": 3,
+                    "output_tokens": 5,
+                    "total_tokens": 10,
+                    "cost_cny": Decimal("0.0202"),
+                },
+                {
+                    "model": "model-a",
+                    "cache_hit_tokens": 40 - offset,
+                    "cache_miss_tokens": 20,
+                    "output_tokens": 10,
+                    "total_tokens": 70 - offset,
+                    "cost_cny": Decimal("0.1001"),
+                },
+            ],
+        }
+        for offset in range(6, -1, -1)
+    ]
+    trend = TrendCard()
+    trend.set_rows(
+        [{"date": current.isoformat(), "cost_cny": Decimal("0.1203"), "tokens": 80}],
+        today=current,
+        currency="USD",
+        model_rows=model_rows,
+        model_usage_enabled=True,
+        provider_id="nayuto",
+    )
+    trend.resize(540, TOP_SECTION_HEIGHT)
+    trend.show()
+    trend.model_button.click()
+    APP.processEvents()
+
+    assert trend.title.text() == "近 7 天各模型 Token 使用量"
+    assert trend._model_order == ["model-a", "model-b"]
+    assert len(trend._values) == 14
+    assert len(trend._bar_positions) == 14
+    assert trend._bar_positions[2] - trend._bar_positions[0] == pytest.approx(1.0)
+    assert trend._series.opts["width"] < trend.BAR_WIDTH
+    first_color = trend._series.opts["brushes"][0].color()
+    assert trend._series.opts["brushes"][2].color() == first_color
+
+    tooltip = trend.tooltip_text(0)
+    expected_order = [
+        "08/09　总计",
+        "模型　model-a",
+        "输入（命中缓存）",
+        "输入（未命中缓存）",
+        "输出",
+        "缓存命中率",
+        "当日消耗金额　$0.1001",
+    ]
+    assert all(text in tooltip for text in expected_order)
+    assert [tooltip.index(text) for text in expected_order] == sorted(
+        tooltip.index(text) for text in expected_order
+    )
+    scene_point = trend.plot.getViewBox().mapViewToScene(
+        QPointF(trend._bar_positions[0], trend._values[0] / 2)
+    )
+    trend._on_mouse_moved((scene_point,))
+    assert trend.hover_tooltip.isVisible()
+    assert trend.hover_tooltip.model_label.text() == "model-a"
+    assert trend.hover_tooltip.cost_label.text() == "$0.1001"
+    assert trend.plot.toolTip() == ""
+
+    trend.amount_button.click()
+    assert trend.title.text() == "近 7 天使用金额"
+    trend.model_button.click()
+    assert trend._model_order == ["model-a", "model-b"]
+    trend.close()
+
+
+def test_nayuto_model_trend_keeps_seven_dates_and_uses_own_empty_state():
+    current = date(2026, 8, 15)
+    trend = TrendCard()
+    trend.set_rows(
+        [],
+        today=current,
+        currency="USD",
+        model_rows=[],
+        model_usage_enabled=True,
+        provider_id="nayuto",
+    )
+    trend.model_button.click()
+
+    assert trend._dates == [current - timedelta(days=offset) for offset in range(6, -1, -1)]
+    assert trend._model_order == []
+    assert trend._values == []
+    assert not trend.empty_label.isHidden()
+    assert "暂无模型用量" in trend.empty_label.text()
+    assert trend.plot.toolTip() == ""
+    trend.close()
+
+
+def test_nayuto_single_model_trend_uses_current_theme_accent():
+    controller = configure_theme(APP, "dark")
+    controller.set_appearance("dark", "#D14C2F", 82)
+    current = date(2026, 8, 15)
+    trend = TrendCard()
+    try:
+        trend.set_rows(
+            [],
+            today=current,
+            currency="USD",
+            model_rows=[
+                {
+                    "date": current.isoformat(),
+                    "models": [
+                        {
+                            "model": "gpt-5.6-terra",
+                            "cache_hit_tokens": 10,
+                            "cache_miss_tokens": 20,
+                            "output_tokens": 5,
+                            "total_tokens": 35,
+                            "cost_cny": Decimal("0.2833"),
+                        }
+                    ],
+                }
+            ],
+            model_usage_enabled=True,
+            provider_id="nayuto",
+        )
+        trend.model_button.click()
+
+        assert trend._model_order == ["gpt-5.6-terra"]
+        assert {
+            brush.color().name().upper() for brush in trend._series.opts["brushes"]
+        } == {"#D14C2F"}
+        assert "#d14c2f" in trend._legend_labels["gpt-5.6-terra"].styleSheet().lower()
+    finally:
+        controller.set_appearance("dark", DARK_THEME.accent, 100)
+        trend.close()
 
 
 def test_custom_accent_updates_trend_and_minute_bar_and_line_series():
@@ -319,6 +463,7 @@ def test_panel_quick_switches_provider_and_renders_subscription_quota():
     assert not panel.activity_card.isHidden()
     assert panel.activity_mode_segment.isHidden()
     assert panel.trend.title.toolTip().endswith("当天 Token 为本机会话日志估算")
+    assert panel.trend.plot.toolTip() == ""
     assert panel.activity_summary.toolTip() == "来自 Codex 账号统计，不含本机估算"
     assert panel.status_text.text() == (
         "额度/热力图/底部统计：接口数据 · 近 7 天：接口 + 今日本机估算"
@@ -810,6 +955,66 @@ def test_minute_chart_aggregates_configured_time_buckets_and_costs():
     chart.close()
 
 
+def test_minute_chart_aggregates_all_models_in_one_and_multi_minute_buckets():
+    chart = MinuteUsageChart()
+    rows = [
+        {"minute": 600, "token_type": "RESPONSE_TOKEN", "token_amount": 10},
+        {"minute": 604, "token_type": "RESPONSE_TOKEN", "token_amount": 8},
+        {"minute": 605, "token_type": "RESPONSE_TOKEN", "token_amount": 4},
+    ]
+    model_rows = [
+        {
+            "minute": 600,
+            "model": "model-b",
+            "cache_hit_tokens": 0,
+            "cache_miss_tokens": 0,
+            "output_tokens": 5,
+            "cost_cny": Decimal("0.01"),
+        },
+        {
+            "minute": 600,
+            "model": "model-a",
+            "cache_hit_tokens": 0,
+            "cache_miss_tokens": 0,
+            "output_tokens": 5,
+            "cost_cny": Decimal("0.01"),
+        },
+        {
+            "minute": 604,
+            "model": "model-a",
+            "cache_hit_tokens": 0,
+            "cache_miss_tokens": 0,
+            "output_tokens": 8,
+            "cost_cny": Decimal("0.02"),
+        },
+        {
+            "minute": 605,
+            "model": "model-c",
+            "cache_hit_tokens": 0,
+            "cache_miss_tokens": 0,
+            "output_tokens": 4,
+            "cost_cny": Decimal("0.03"),
+        },
+    ]
+    chart.set_rows(rows, "recorded", interval_minutes=5, model_rows=model_rows)
+
+    assert chart._model_names[chart._bucket_index_for_minute(600)] == [
+        "model-a",
+        "model-b",
+    ]
+    assert "模型　model-a、model-b" in chart.tooltip_text(604)
+    assert "模型　model-c" in chart.tooltip_text(605)
+    chart._show_hover(600, QPoint(120, 50))
+    assert chart.hover_tooltip.model_label.text() == "model-a、model-b"
+    assert not chart.hover_tooltip.model_row.isHidden()
+
+    chart.set_rows(rows, "recorded", interval_minutes=1)
+    assert "模型　" not in chart.tooltip_text(600)
+    chart._show_hover(600, QPoint(120, 50))
+    assert chart.hover_tooltip.model_row.isHidden()
+    chart.close()
+
+
 def test_minute_chart_arbitrary_interval_aligns_to_midnight_and_clips_last_bucket():
     chart = MinuteUsageChart()
     chart.set_rows(
@@ -1225,6 +1430,42 @@ def test_minute_chart_cost_tooltip_handles_missing_zero_and_plot_boundaries():
     chart.close()
 
 
+def test_minute_chart_model_tooltip_stays_single_line_and_keeps_cost_visible():
+    chart = MinuteUsageChart()
+    chart.resize(900, 220)
+    chart.set_rows(
+        [{"minute": 600, "token_type": "RESPONSE_TOKEN", "token_amount": 1}],
+        "recorded",
+        cost_rows=[{"minute": 600, "cost_cny": Decimal("0.2833")}],
+        currency="USD",
+        model_rows=[
+            {
+                "minute": 600,
+                "model": "gpt-5.6-terra",
+                "cache_hit_tokens": 0,
+                "cache_miss_tokens": 0,
+                "output_tokens": 1,
+            }
+        ],
+    )
+    chart.show()
+    APP.processEvents()
+
+    chart._show_hover(600, QPoint(chart.plot.width() - 1, chart.plot.height() - 1))
+    tooltip = chart.hover_tooltip
+    APP.processEvents()
+
+    assert tooltip.model_label.text() == "gpt-5.6-terra"
+    assert not tooltip.model_label.wordWrap()
+    assert tooltip.model_label.height() <= tooltip.model_label.fontMetrics().height() + 2
+    cost_bottom = tooltip.cost_label.mapTo(
+        tooltip, tooltip.cost_label.rect().bottomRight()
+    ).y()
+    assert cost_bottom < tooltip.contentsRect().bottom()
+    assert tooltip.y() + tooltip.height() <= chart.plot.height() - 6
+    chart.close()
+
+
 def test_nayuto_reuses_amount_ball_and_exact_minute_ui_with_usd_precision():
     data = TokenData(
         currency="USD",
@@ -1247,6 +1488,16 @@ def test_nayuto_reuses_amount_ball_and_exact_minute_ui_with_usd_precision():
         ],
         minute_cost_usage=[
             {"minute": 600, "cost_cny": Decimal("0.0861")}
+        ],
+        minute_model_usage=[
+            {
+                "minute": 600,
+                "model": "model-a",
+                "cache_hit_tokens": 3,
+                "cache_miss_tokens": 2,
+                "output_tokens": 5,
+                "cost_cny": Decimal("0.0861"),
+            }
         ],
         minute_usage_status="recorded",
         minute_usage_date="2026-08-15",
@@ -1285,13 +1536,129 @@ def test_nayuto_reuses_amount_ball_and_exact_minute_ui_with_usd_precision():
             1 if key == "MINUTE_USAGE_INTERVAL_MINUTES" else default
         )
         panel._set_activity_view("minute")
+        assert "模型　model-a" in panel.minute_chart.tooltip_text(600)
         assert "本分钟消耗金额　$0.0861" in panel.minute_chart.tooltip_text(600)
         panel.minute_chart._show_hover(600, QPoint(120, 50))
+        assert panel.minute_chart.hover_tooltip.model_label.text() == "model-a"
         assert panel.minute_chart.hover_tooltip.cost_label.text() == "$0.0861"
+        assert panel.trend.plot.toolTip() == ""
 
     panel.close()
     widget._closed = True
     widget.hide()
+
+
+def test_nayuto_model_views_restore_per_provider_and_history_keeps_minute_models():
+    current = date(2026, 8, 15)
+    previous = current - timedelta(days=1)
+    data = TokenData(
+        currency="USD",
+        status="ok",
+        daily_usage=[
+            {"date": previous.isoformat(), "tokens": 6, "cost_cny": Decimal("0.01")},
+            {"date": current.isoformat(), "tokens": 10, "cost_cny": Decimal("0.02")},
+        ],
+        daily_model_usage=[
+            {
+                "date": previous.isoformat(),
+                "models": [
+                    {
+                        "model": "model-history",
+                        "cache_hit_tokens": 1,
+                        "cache_miss_tokens": 2,
+                        "output_tokens": 3,
+                        "total_tokens": 6,
+                        "cost_cny": Decimal("0.01"),
+                    }
+                ],
+            },
+            {
+                "date": current.isoformat(),
+                "models": [
+                    {
+                        "model": "model-current",
+                        "cache_hit_tokens": 3,
+                        "cache_miss_tokens": 2,
+                        "output_tokens": 5,
+                        "total_tokens": 10,
+                        "cost_cny": Decimal("0.02"),
+                    }
+                ],
+            },
+        ],
+        minute_usage=[
+            {"minute": 600, "token_type": "RESPONSE_TOKEN", "token_amount": 10}
+        ],
+        minute_model_usage=[
+            {
+                "minute": 600,
+                "model": "model-current",
+                "cache_hit_tokens": 0,
+                "cache_miss_tokens": 0,
+                "output_tokens": 10,
+                "cost_cny": Decimal("0.02"),
+            }
+        ],
+        minute_usage_history={
+            previous.isoformat(): [
+                {"minute": 600, "token_type": "RESPONSE_TOKEN", "token_amount": 6}
+            ]
+        },
+        minute_model_usage_history={
+            previous.isoformat(): [
+                {
+                    "minute": 600,
+                    "model": "model-history",
+                    "cache_hit_tokens": 0,
+                    "cache_miss_tokens": 0,
+                    "output_tokens": 6,
+                    "cost_cny": Decimal("0.01"),
+                }
+            ]
+        },
+        minute_usage_status="recorded",
+        minute_usage_date=current.isoformat(),
+        minute_usage_days=[previous.isoformat(), current.isoformat()],
+        minute_usage_source="provider",
+        per_provider=[PerProviderData("nayuto", "NayutoAI", currency="USD", status="ok")],
+    )
+    panel = MainPanel()
+    with patch(
+        "ui.qt_panel.config_manager.get",
+        side_effect=lambda key, default=None: (
+            1
+            if key == "MINUTE_USAGE_INTERVAL_MINUTES"
+            else 3
+            if key == "MINUTE_USAGE_RETENTION_DAYS"
+            else default
+        ),
+    ):
+        panel.update_data(data)
+        assert not panel.trend.view_segment.isHidden()
+        panel.trend.model_button.click()
+        assert panel.trend.title.text() == "近 7 天各模型 Token 使用量"
+
+        panel.minute_activity_button.click()
+        panel.minute_previous_button.click()
+        assert "模型　model-history" in panel.minute_chart.tooltip_text(600)
+
+        other = sample_data()
+        other.per_provider = [PerProviderData("deepseek", "DeepSeek", status="ok")]
+        panel.update_data(other)
+        assert panel.trend.view_segment.isHidden()
+        assert panel.trend.title.text() == "近 7 天使用金额"
+        assert "模型　" not in panel.minute_chart.tooltip_text(600)
+
+        panel.update_data(data)
+        assert panel.trend.model_button.isChecked()
+        assert panel.trend.title.text() == "近 7 天各模型 Token 使用量"
+
+    assert panel.activity_stack.count() == 2
+    assert panel.annual_activity_button.text() == "年度活动"
+    assert panel.minute_activity_button.text() == "今日分时"
+    assert len(panel.statistics._values) == 5
+    assert panel.status_text.text()
+    panel.close()
 
 
 def test_nayuto_settings_uses_manual_bearer_capture_and_clean_display_name():

--- a/tests/test_refresh.py
+++ b/tests/test_refresh.py
@@ -352,6 +352,10 @@ class RefreshTests(unittest.TestCase):
         relay = TokenData(
             currency="USD",
             today_cost_cny=1,
+            daily_model_usage=[
+                {"date": "2026-08-15", "models": [{"model": "model-a"}]}
+            ],
+            minute_model_usage=[{"minute": 1, "model": "model-a"}],
             per_provider=[PerProviderData("nayuto", "NayutoAI", currency="USD")],
         )
         widget._data = current
@@ -362,6 +366,12 @@ class RefreshTests(unittest.TestCase):
         self.assertIs(widget._data, current)
         self.assertTrue(widget._refreshing)
         self.assertIs(widget._provider_results["nayuto"], relay)
+        self.assertEqual(
+            widget._provider_results["nayuto"].minute_model_usage[0]["model"],
+            "model-a",
+        )
+        self.assertEqual(widget._data.per_provider[0].provider_id, "deepseek")
+        self.assertEqual(widget._data.daily_model_usage, [])
         widget._apply_update.assert_not_called()
 
     def test_current_provider_result_updates_interface(self):

--- a/ui/formatting.py
+++ b/ui/formatting.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from math import ceil
 
 from ui.activity import compact_tokens
+
+_SHANGHAI_TIMEZONE = timezone(timedelta(hours=8))
 
 
 def _currency_prefix(currency: str) -> str:
@@ -74,6 +76,17 @@ def format_reset_countdown(value: datetime | None, now: datetime | None = None) 
     if hours:
         return f"{hours} 小时 {minutes} 分钟后重置"
     return f"{minutes} 分钟后重置"
+
+
+def format_codex_reset_time(value: datetime | None, *, compact: bool = False) -> str:
+    if value is None:
+        return "重置时间未知"
+    local_value = (
+        value.astimezone(_SHANGHAI_TIMEZONE) if value.tzinfo is not None else value
+    )
+    if compact:
+        return f"{local_value.month}月{local_value.day}日{local_value:%H:%M}"
+    return f"{local_value.month}月{local_value.day}日 {local_value:%H:%M}重置"
 
 
 def format_plan_active_until(value: datetime | None) -> str:

--- a/ui/qt_panel.py
+++ b/ui/qt_panel.py
@@ -50,7 +50,6 @@ from PySide6.QtWidgets import (
     QStyledItemDelegate,
     QStyleOptionViewItem,
     QToolButton,
-    QToolTip,
     QVBoxLayout,
     QWidget,
 )
@@ -823,10 +822,132 @@ class MetricCard(QFrame):
         self.title_label.setText(title)
 
 
+class TrendUsageTooltip(QFrame):
+    """Top-chart-owned tooltip; never competes with Qt's global QToolTip."""
+
+    def __init__(self, parent: QWidget):
+        super().__init__(parent)
+        self.setObjectName("minuteTooltip")
+        self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(9, 7, 9, 7)
+        layout.setSpacing(4)
+
+        header = QHBoxLayout()
+        self.date_label = QLabel()
+        self.date_label.setObjectName("minuteTooltipTitle")
+        self.total_label = QLabel()
+        self.total_label.setObjectName("minuteTooltipValue")
+        header.addWidget(self.date_label)
+        header.addStretch(1)
+        header.addWidget(self.total_label)
+        layout.addLayout(header)
+
+        self.model_row = QWidget()
+        model_layout = QHBoxLayout(self.model_row)
+        model_layout.setContentsMargins(0, 0, 0, 0)
+        model_name = QLabel("模型")
+        model_name.setObjectName("minuteTooltipMuted")
+        self.model_label = QLabel()
+        self.model_label.setObjectName("minuteTooltipValue")
+        self.model_label.setWordWrap(False)
+        self.model_label.setMaximumWidth(240)
+        self.model_label.setSizePolicy(
+            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed
+        )
+        self.model_label.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+        model_layout.addWidget(model_name)
+        model_layout.addStretch(1)
+        model_layout.addWidget(self.model_label)
+        layout.addWidget(self.model_row)
+
+        self.token_rows = QWidget()
+        token_layout = QGridLayout(self.token_rows)
+        token_layout.setContentsMargins(0, 0, 0, 0)
+        token_layout.setHorizontalSpacing(7)
+        token_layout.setVerticalSpacing(3)
+        self.swatches: list[QLabel] = []
+        self.value_labels: list[QLabel] = []
+        for row, label in enumerate(("输入（命中缓存）", "输入（未命中缓存）", "输出")):
+            swatch = QLabel()
+            swatch.setFixedSize(8, 8)
+            name = QLabel(label)
+            name.setObjectName("minuteTooltipMuted")
+            value = QLabel("0")
+            value.setObjectName("minuteTooltipValue")
+            value.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+            token_layout.addWidget(swatch, row, 0)
+            token_layout.addWidget(name, row, 1)
+            token_layout.addWidget(value, row, 2)
+            self.swatches.append(swatch)
+            self.value_labels.append(value)
+        layout.addWidget(self.token_rows)
+
+        self.footer = QWidget()
+        footer_layout = QVBoxLayout(self.footer)
+        footer_layout.setContentsMargins(0, 0, 0, 0)
+        footer_layout.setSpacing(4)
+        divider = QFrame()
+        divider.setObjectName("divider")
+        divider.setFrameShape(QFrame.Shape.HLine)
+        divider.setFixedHeight(1)
+        footer_layout.addWidget(divider)
+        rate_row = QHBoxLayout()
+        rate_name = QLabel("缓存命中率")
+        rate_name.setObjectName("minuteTooltipMuted")
+        self.rate_label = QLabel("--")
+        self.rate_label.setObjectName("minuteTooltipValue")
+        rate_row.addWidget(rate_name)
+        rate_row.addStretch(1)
+        rate_row.addWidget(self.rate_label)
+        footer_layout.addLayout(rate_row)
+        cost_row = QHBoxLayout()
+        cost_name = QLabel("当日消耗金额")
+        cost_name.setObjectName("minuteTooltipMuted")
+        self.cost_label = QLabel("--")
+        self.cost_label.setObjectName("minuteTooltipCost")
+        cost_row.addWidget(cost_name)
+        cost_row.addStretch(1)
+        cost_row.addWidget(self.cost_label)
+        footer_layout.addLayout(cost_row)
+        layout.addWidget(self.footer)
+        self.hide()
+
+    def set_simple(self, usage_date: date, value: str) -> None:
+        self.date_label.setText(usage_date.isoformat())
+        self.total_label.setText(value)
+        self.model_row.hide()
+        self.token_rows.hide()
+        self.footer.hide()
+
+    def set_model(self, usage_date: date, row: dict, currency: str) -> None:
+        hit = int(row.get("cache_hit_tokens", 0) or 0)
+        miss = int(row.get("cache_miss_tokens", 0) or 0)
+        output = int(row.get("output_tokens", 0) or 0)
+        total = hit + miss + output
+        self.date_label.setText(usage_date.strftime("%m/%d"))
+        self.total_label.setText(f"总计 {compact_tokens(total)}")
+        self.model_label.setText(str(row.get("model") or "unknown"))
+        for label, value in zip(self.value_labels, (hit, miss, output)):
+            label.setText(compact_tokens(value))
+        self.rate_label.setText(
+            "--" if hit + miss == 0 else f"{hit / (hit + miss) * 100:.1f}%"
+        )
+        self.cost_label.setText(format_minute_money(row.get("cost_cny"), currency))
+        self.model_row.show()
+        self.token_rows.show()
+        self.footer.show()
+
+    def refresh_colors(self, colors: tuple[QColor, QColor, QColor]) -> None:
+        for swatch, color in zip(self.swatches, colors):
+            swatch.setStyleSheet(f"background: {color.name()}; border-radius: 2px;")
+
+
 class TrendCard(QFrame):
-    """Seven-day provider activity rendered as seven flat bars."""
+    """Seven-day amount/token trend with an optional per-model grouped view."""
 
     BAR_WIDTH = 0.36
+    MODEL_GROUP_WIDTH = 0.76
 
     def __init__(self, parent: QWidget | None = None):
         super().__init__(parent)
@@ -835,19 +956,58 @@ class TrendCard(QFrame):
         layout.setContentsMargins(8, 5, 0, 2)
         layout.setSpacing(2)
 
+        heading = QHBoxLayout()
+        heading.setContentsMargins(0, 0, 6, 0)
         self.title = QLabel("近 7 天使用金额")
         self.title.setObjectName("sectionTitle")
-        layout.addWidget(self.title)
+        heading.addWidget(self.title)
+        heading.addStretch(1)
+        self.view_segment = QFrame()
+        self.view_segment.setObjectName("activityModeSegment")
+        self.view_segment.setFixedSize(134, 24)
+        segment_layout = QHBoxLayout(self.view_segment)
+        segment_layout.setContentsMargins(1, 1, 1, 1)
+        segment_layout.setSpacing(0)
+        self._view_group = QButtonGroup(self)
+        self._view_group.setExclusive(True)
+        self.amount_button = self._view_button("金额趋势", 66)
+        self.model_button = self._view_button("模型使用", 66)
+        self._view_group.addButton(self.amount_button)
+        self._view_group.addButton(self.model_button)
+        segment_layout.addWidget(self.amount_button)
+        segment_layout.addWidget(self.model_button)
+        self.amount_button.clicked.connect(lambda: self._set_view("amount"))
+        self.model_button.clicked.connect(lambda: self._set_view("model"))
+        heading.addWidget(self.view_segment)
+        self.view_segment.hide()
+        layout.addLayout(heading)
 
-        self.plot = pg.PlotWidget(
-            axisItems={"left": MoneyAxis(orientation="left")},
-        )
+        self.legend_scroll = QScrollArea()
+        self.legend_scroll.setFrameShape(QFrame.Shape.NoFrame)
+        self.legend_scroll.setWidgetResizable(False)
+        self.legend_scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.legend_scroll.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.legend_scroll.setFixedHeight(18)
+        self.legend_widget = QWidget()
+        self.legend_layout = QHBoxLayout(self.legend_widget)
+        self.legend_layout.setContentsMargins(0, 0, 0, 0)
+        self.legend_layout.setSpacing(10)
+        self.legend_scroll.setWidget(self.legend_widget)
+        self.legend_scroll.hide()
+        layout.addWidget(self.legend_scroll)
+
+        self.plot = pg.PlotWidget(axisItems={"left": MoneyAxis(orientation="left")})
         self.plot.setStyleSheet("border: 0;")
-        self.plot.setMinimumHeight(100)
+        self.plot.setMinimumHeight(82)
         self.plot.setMouseEnabled(x=False, y=False)
         self.plot.hideButtons()
         self.plot.setMenuEnabled(False)
+        self.plot.setToolTip("")
         self.plot.showGrid(x=False, y=True, alpha=0.14)
+        self.empty_label = QLabel("近 7 天暂无模型用量", self.plot)
+        self.empty_label.setObjectName("muted")
+        self.empty_label.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
+        self.empty_label.hide()
 
         axis_font = QFont("Microsoft YaHei UI", 8)
         left_axis = self.plot.getAxis("left")
@@ -863,26 +1023,45 @@ class TrendCard(QFrame):
 
         self._dates: list[date] = []
         self._values: list[float] = []
+        self._standard_rows: list[dict] = []
+        self._daily_model_rows: list[dict] = []
+        self._model_order: list[str] = []
+        self._legend_labels: dict[str, QLabel] = {}
+        self._bar_models: list[str] = []
+        self._bar_positions: list[float] = []
+        self._bar_rows: list[dict] = []
+        self._bar_width = self.BAR_WIDTH
         self._currency = "CNY"
         self._token_mode = False
+        self._provider_id = ""
+        self._view = "amount"
+        self._view_by_provider: dict[str, str] = {}
         self._series: pg.BarGraphItem | None = None
         self._hover_index: int | None = None
+        self.hover_tooltip = TrendUsageTooltip(self)
         self._mouse_proxy = pg.SignalProxy(
-            self.plot.scene().sigMouseMoved,
-            rateLimit=60,
-            slot=self._on_mouse_moved,
+            self.plot.scene().sigMouseMoved, rateLimit=60, slot=self._on_mouse_moved
         )
         layout.addWidget(self.plot, 1)
         self._connect_theme_changes()
         self.set_rows([])
 
+    @staticmethod
+    def _view_button(text: str, width: int) -> QToolButton:
+        button = QToolButton()
+        button.setObjectName("activityModeButton")
+        button.setText(text)
+        button.setCheckable(True)
+        button.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
+        button.setFixedSize(width, 22)
+        return button
+
     def _connect_theme_changes(self) -> None:
         try:
-            theme_controller().changed.connect(self._on_theme_changed)
+            controller = theme_controller()
         except RuntimeError:
-            # Standalone component tests may construct the chart before an app-level
-            # controller exists; production configures the theme before any window.
-            pass
+            return
+        controller.changed.connect(self._on_theme_changed)
 
     def set_rows(
         self,
@@ -890,60 +1069,184 @@ class TrendCard(QFrame):
         today: date | None = None,
         currency: str = "CNY",
         token_mode: bool = False,
+        *,
+        model_rows: list[dict] | None = None,
+        model_usage_enabled: bool = False,
+        provider_id: str = "",
     ) -> None:
         self._currency = str(currency or "CNY").upper()
         self._token_mode = token_mode
-        self.title.setText("近 7 天 Token 使用量" if token_mode else "近 7 天使用金额")
+        self._provider_id = str(provider_id or "")
+        self._standard_rows = list(rows)
+        self._daily_model_rows = list(model_rows or [])
+        current = today or date.today()
+        self._dates = [current - timedelta(days=offset) for offset in range(6, -1, -1)]
+        self.view_segment.setVisible(model_usage_enabled)
+        self._view = (
+            self._view_by_provider.get(self._provider_id, "amount")
+            if model_usage_enabled
+            else "amount"
+        )
+        amount_blocker = QSignalBlocker(self.amount_button)
+        model_blocker = QSignalBlocker(self.model_button)
+        self.amount_button.setChecked(self._view == "amount")
+        self.model_button.setChecked(self._view == "model")
+        del amount_blocker, model_blocker
+        self._render()
+
+    def _set_view(self, view: str) -> None:
+        if view not in {"amount", "model"}:
+            return
+        self._view = view
+        if self._provider_id:
+            self._view_by_provider[self._provider_id] = view
+        self._render()
+
+    def _render(self) -> None:
+        self._hide_hover()
+        self.plot.clear()
+        self.plot.setToolTip("")
         left_axis = self.plot.getAxis("left")
         left_axis.currency = self._currency
-        left_axis.token_mode = token_mode
-        current = today or date.today()
-        by_date = {str(row.get("date")): row for row in rows}
-        self._dates = [current - timedelta(days=offset) for offset in range(6, -1, -1)]
-        value_key = "tokens" if token_mode else "cost_cny"
-        self._values = [
-            float(by_date.get(day.isoformat(), {}).get(value_key, 0) or 0)
-            for day in self._dates
-        ]
-        self.plot.clear()
-
+        model_mode = self._view == "model" and not self.view_segment.isHidden()
+        left_axis.token_mode = self._token_mode or model_mode
+        if model_mode:
+            self._prepare_model_bars()
+            self.title.setText("近 7 天各模型 Token 使用量")
+            self.legend_scroll.show()
+            self.empty_label.setVisible(not self._model_order)
+        else:
+            by_date = {str(row.get("date")): row for row in self._standard_rows}
+            value_key = "tokens" if self._token_mode else "cost_cny"
+            self._values = [
+                float(by_date.get(day.isoformat(), {}).get(value_key, 0) or 0)
+                for day in self._dates
+            ]
+            self._bar_positions = [float(index) for index in range(7)]
+            self._bar_rows = []
+            self._bar_models = []
+            self._bar_width = self.BAR_WIDTH
+            self.title.setText(
+                "近 7 天 Token 使用量" if self._token_mode else "近 7 天使用金额"
+            )
+            self.legend_scroll.hide()
+            self.empty_label.hide()
         tokens = current_theme()
         self._series = pg.BarGraphItem(
-            x=list(range(7)),
+            x=self._bar_positions,
             height=self._values,
-            width=self.BAR_WIDTH,
+            width=self._bar_width,
             pen=pg.mkPen(tokens.accent),
             brush=pg.mkBrush(tokens.accent),
         )
         self.plot.addItem(self._series)
-
         self.plot.getAxis("bottom").setTicks(
             [[(index, day.strftime("%m/%d")) for index, day in enumerate(self._dates)]]
         )
-        # Preserve half a day at each edge so all seven bars stay fully visible.
         self.plot.setXRange(-0.5, 6.5, padding=0)
         maximum = max(self._values, default=0.0)
-        tick_max = max(1.0 if token_mode else 0.01, maximum)
-        range_max = tick_max * 1.08 if maximum > 0 else tick_max
-        self.plot.setYRange(0, range_max, padding=0)
+        token_axis = self._token_mode or model_mode
+        tick_max = max(1.0 if token_axis else 0.01, maximum)
+        self.plot.setYRange(0, tick_max * 1.08 if maximum > 0 else tick_max, padding=0)
         self.plot.getAxis("left").setTicks(
             [[
                 (
                     tick_max * index / 3,
                     format_token_axis(tick_max * index / 3)
-                    if token_mode
+                    if token_axis
                     else format_money_axis(tick_max * index / 3, self._currency),
                 )
                 for index in range(4)
             ]]
         )
         self._hover_index = None
+        self._position_empty_label()
         self.refresh_theme()
+
+    def _prepare_model_bars(self) -> None:
+        rows_by_date = {
+            str(row.get("date")): row.get("models", [])
+            for row in self._daily_model_rows
+        }
+        totals: dict[str, int] = {}
+        lookup: dict[tuple[str, str], dict] = {}
+        for day in self._dates:
+            for raw in rows_by_date.get(day.isoformat(), []) or []:
+                if not isinstance(raw, dict):
+                    continue
+                model = str(raw.get("model") or "unknown")
+                row = dict(raw)
+                row["model"] = model
+                total = int(row.get("total_tokens", 0) or 0)
+                totals[model] = totals.get(model, 0) + total
+                lookup[(day.isoformat(), model)] = row
+        self._model_order = sorted(totals, key=lambda model: (-totals[model], model))
+        model_count = len(self._model_order)
+        slot_width = self.MODEL_GROUP_WIDTH / max(1, model_count)
+        self._bar_width = slot_width * 0.82 if model_count else self.BAR_WIDTH
+        self._values = []
+        self._bar_positions = []
+        self._bar_models = []
+        self._bar_rows = []
+        for day_index, day in enumerate(self._dates):
+            for model_index, model in enumerate(self._model_order):
+                row = lookup.get(
+                    (day.isoformat(), model),
+                    {
+                        "model": model,
+                        "cache_hit_tokens": 0,
+                        "cache_miss_tokens": 0,
+                        "output_tokens": 0,
+                        "total_tokens": 0,
+                        "cost_cny": Decimal("0"),
+                    },
+                )
+                offset = (model_index - (model_count - 1) / 2) * slot_width
+                self._bar_positions.append(day_index + offset)
+                self._values.append(float(row.get("total_tokens", 0) or 0))
+                self._bar_models.append(model)
+                self._bar_rows.append(row)
+        self._rebuild_model_legend()
+
+    def _rebuild_model_legend(self) -> None:
+        while self.legend_layout.count():
+            item = self.legend_layout.takeAt(0)
+            if item.widget() is not None:
+                item.widget().deleteLater()
+        self._legend_labels = {}
+        for model in self._model_order:
+            label = QLabel(f"■ {model}")
+            label.setObjectName("muted")
+            label.setToolTip(model)
+            label.setAccessibleName(model)
+            label.setStyleSheet(f"color: {self._model_color(model).name()};")
+            self._legend_labels[model] = label
+            self.legend_layout.addWidget(label)
+        self.legend_layout.addStretch(1)
+        self.legend_widget.adjustSize()
+
+    def _model_color(self, model: str) -> QColor:
+        tokens = current_theme()
+        if len(self._model_order) == 1:
+            return QColor(tokens.accent)
+        base = QColor(tokens.accent)
+        base_hue = base.hslHue() if base.hslHue() >= 0 else 345
+        stable = sum((index + 1) * ord(char) for index, char in enumerate(model))
+        hue = (base_hue + stable % 281) % 360
+        lightness = 172 if tokens.name == "dark" else 116
+        return QColor.fromHsl(hue, 150, lightness)
+
+    @staticmethod
+    def _token_colors() -> tuple[QColor, QColor, QColor]:
+        tokens = current_theme()
+        return (
+            QColor(tokens.accent).lighter(145),
+            QColor(tokens.accent),
+            QColor(tokens.accent).darker(130),
+        )
 
     def refresh_theme(self) -> None:
         tokens = current_theme()
-        # The selected layout is one continuous surface; the chart must not
-        # introduce a nested rectangular card behind the bars.
         _make_plot_background_transparent(self.plot)
         left_axis = self.plot.getAxis("left")
         bottom_axis = self.plot.getAxis("bottom")
@@ -953,7 +1256,23 @@ class TrendCard(QFrame):
         axis_color.setAlpha(96)
         left_axis.setPen(pg.mkPen(axis_color))
         bottom_axis.setPen(pg.mkPen(axis_color))
-        if self._series is not None:
+        model_mode = self._view == "model" and not self.view_segment.isHidden()
+        if self._series is not None and model_mode:
+            colors = [self._model_color(model) for model in self._bar_models]
+            if self._hover_index is not None:
+                colors[self._hover_index] = (
+                    QColor(tokens.accent_hover)
+                    if len(self._model_order) == 1
+                    else colors[self._hover_index].lighter(125)
+                )
+            if colors:
+                self._series.setOpts(
+                    pens=[pg.mkPen(color) for color in colors],
+                    brushes=[pg.mkBrush(color) for color in colors],
+                )
+            for model, label in self._legend_labels.items():
+                label.setStyleSheet(f"color: {self._model_color(model).name()};")
+        elif self._series is not None:
             if self._hover_index is None:
                 self._series.setOpts(
                     pens=None,
@@ -964,46 +1283,117 @@ class TrendCard(QFrame):
             else:
                 self._series.setOpts(
                     pens=[
-                        pg.mkPen(tokens.accent_hover if index == self._hover_index else tokens.accent)
+                        pg.mkPen(
+                            tokens.accent_hover
+                            if index == self._hover_index
+                            else tokens.accent
+                        )
                         for index in range(len(self._values))
                     ],
                     brushes=[
-                        pg.mkBrush(tokens.accent_hover if index == self._hover_index else tokens.accent)
+                        pg.mkBrush(
+                            tokens.accent_hover
+                            if index == self._hover_index
+                            else tokens.accent
+                        )
                         for index in range(len(self._values))
                     ],
                 )
+        self.hover_tooltip.refresh_colors(self._token_colors())
 
     def _on_theme_changed(self, _mode: str, _resolved: str) -> None:
         self.refresh_theme()
 
+    def resizeEvent(self, event) -> None:
+        super().resizeEvent(event)
+        self._position_empty_label()
+
+    def _position_empty_label(self) -> None:
+        self.empty_label.adjustSize()
+        self.empty_label.move(
+            max(0, (self.plot.width() - self.empty_label.width()) // 2),
+            max(0, (self.plot.height() - self.empty_label.height()) // 2),
+        )
+
     def _on_mouse_moved(self, event) -> None:
         scene_pos = event[0]
-        if not self.plot.sceneBoundingRect().contains(scene_pos):
+        view_box = self.plot.getViewBox()
+        if not view_box.sceneBoundingRect().contains(scene_pos):
             self._hide_hover()
             return
-        point = self.plot.getViewBox().mapSceneToView(scene_pos)
-        index = int(round(point.x()))
-        if not 0 <= index < len(self._values) or abs(point.x() - index) > self.BAR_WIDTH / 2:
+        point = view_box.mapSceneToView(scene_pos)
+        if not self._bar_positions:
             self._hide_hover()
             return
-
+        index = min(
+            range(len(self._bar_positions)),
+            key=lambda candidate: abs(point.x() - self._bar_positions[candidate]),
+        )
+        height = self._values[index]
+        if (
+            abs(point.x() - self._bar_positions[index]) > self._bar_width / 2
+            or height <= 0
+            or not 0 <= point.y() <= height
+        ):
+            self._hide_hover()
+            return
         self._hover_index = index
         self.refresh_theme()
         local = self.plot.mapFromScene(scene_pos)
-        QToolTip.showText(
-            self.plot.mapToGlobal(local),
-            self.tooltip_text(index),
-            self.plot,
-        )
+        self._show_tooltip(index, local)
+
+    def _show_tooltip(self, index: int, local: QPoint) -> None:
+        if self._view == "model" and not self.view_segment.isHidden():
+            day_index = index // max(1, len(self._model_order))
+            self.hover_tooltip.set_model(
+                self._dates[day_index], self._bar_rows[index], self._currency
+            )
+        else:
+            self.hover_tooltip.set_simple(
+                self._dates[index],
+                format_codex_tokens(self._values[index])
+                if self._token_mode
+                else format_money(self._values[index], self._currency),
+            )
+        tooltip_layout = self.hover_tooltip.layout()
+        if tooltip_layout is not None:
+            tooltip_layout.activate()
+        self.hover_tooltip.resize(self.hover_tooltip.sizeHint())
+        anchor = self.plot.mapTo(self, local)
+        x = anchor.x() + 10
+        if x + self.hover_tooltip.width() > self.width() - 6:
+            x = anchor.x() - self.hover_tooltip.width() - 10
+        x = max(6, min(x, max(6, self.width() - self.hover_tooltip.width() - 6)))
+        y = max(6, min(anchor.y() + 8, self.height() - self.hover_tooltip.height() - 6))
+        self.hover_tooltip.move(x, y)
+        self.hover_tooltip.raise_()
+        self.hover_tooltip.show()
 
     def _hide_hover(self) -> None:
         had_hover = self._hover_index is not None
         self._hover_index = None
+        self.hover_tooltip.hide()
         if had_hover:
             self.refresh_theme()
-        QToolTip.hideText()
 
     def tooltip_text(self, index: int) -> str:
+        if self._view == "model" and not self.view_segment.isHidden():
+            day_index = index // max(1, len(self._model_order))
+            row = self._bar_rows[index]
+            hit = int(row.get("cache_hit_tokens", 0) or 0)
+            miss = int(row.get("cache_miss_tokens", 0) or 0)
+            output = int(row.get("output_tokens", 0) or 0)
+            total = hit + miss + output
+            rate = "--" if hit + miss == 0 else f"{hit / (hit + miss) * 100:.1f}%"
+            return (
+                f"{self._dates[day_index].strftime('%m/%d')}　总计 {compact_tokens(total)}\n"
+                f"模型　{row.get('model') or 'unknown'}\n"
+                f"输入（命中缓存）　{compact_tokens(hit)}\n"
+                f"输入（未命中缓存）　{compact_tokens(miss)}\n"
+                f"输出　{compact_tokens(output)}\n"
+                f"缓存命中率　{rate}\n"
+                f"当日消耗金额　{format_minute_money(row.get('cost_cny'), self._currency)}"
+            )
         if self._token_mode:
             return (
                 f"{self._dates[index].isoformat()}\n"
@@ -1024,7 +1414,7 @@ class MinuteUsageTooltip(QFrame):
         self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
         layout = QVBoxLayout(self)
         layout.setContentsMargins(9, 7, 9, 7)
-        layout.setSpacing(5)
+        layout.setSpacing(4)
 
         header = QHBoxLayout()
         header.setContentsMargins(0, 0, 0, 0)
@@ -1036,6 +1426,28 @@ class MinuteUsageTooltip(QFrame):
         header.addStretch(1)
         header.addWidget(self.total_label)
         layout.addLayout(header)
+
+        self.model_row = QWidget()
+        model_layout = QHBoxLayout(self.model_row)
+        model_layout.setContentsMargins(0, 0, 0, 0)
+        model_layout.setSpacing(7)
+        model_name = QLabel("模型")
+        model_name.setObjectName("minuteTooltipMuted")
+        self.model_label = QLabel()
+        self.model_label.setObjectName("minuteTooltipValue")
+        self.model_label.setWordWrap(False)
+        self.model_label.setMaximumWidth(240)
+        self.model_label.setSizePolicy(
+            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed
+        )
+        self.model_label.setAlignment(
+            Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+        )
+        model_layout.addWidget(model_name)
+        model_layout.addStretch(1)
+        model_layout.addWidget(self.model_label)
+        layout.addWidget(self.model_row)
+        self.model_row.hide()
 
         rows = QGridLayout()
         rows.setContentsMargins(0, 0, 0, 0)
@@ -1099,6 +1511,7 @@ class MinuteUsageTooltip(QFrame):
         values: tuple[int, int, int],
         cost_cny: Decimal | None,
         currency: str = "CNY",
+        models: list[str] | None = None,
     ) -> None:
         hit, miss, output = values
         total = hit + miss + output
@@ -1112,6 +1525,9 @@ class MinuteUsageTooltip(QFrame):
             self.time_label.setText(f"{start_text}–{end_text}")
             self.cost_name.setText("本时段消耗金额")
         self.total_label.setText(f"总计 {compact_tokens(total)}")
+        model_text = "、".join(models or [])
+        self.model_label.setText(model_text)
+        self.model_row.setVisible(bool(model_text))
         for label, value in zip(self.value_labels, values):
             label.setText(compact_tokens(value))
         self.rate_label.setText(rate)
@@ -1146,6 +1562,7 @@ class MinuteUsageChart(QWidget):
         self._bucket_centers = [float(minute) for minute in range(1440)]
         self._values = {key: [0] * 1440 for key, _label in self.SERIES}
         self._cost_values: list[Decimal | None] = [None] * 1440
+        self._model_names: list[list[str]] = [[] for _minute in range(1440)]
         self._visible = {key: True for key, _label in self.SERIES}
         self._signature: tuple | None = None
         self._updating_region = False
@@ -1245,7 +1662,9 @@ class MinuteUsageChart(QWidget):
         interval_minutes: int = 1,
         chart_type: str = "bar",
         currency: str = "CNY",
+        model_rows: list[dict] | None = None,
     ) -> None:
+        self._hide_hover()
         chart_type = str(chart_type).strip().lower()
         if chart_type not in {"bar", "line"}:
             raise ValueError("分时图表样式必须是 bar 或 line")
@@ -1278,12 +1697,36 @@ class MinuteUsageChart(QWidget):
                 cost_values[bucket_index] = (
                     cost_values[bucket_index] or Decimal(0)
                 ) + cost
+        model_totals: list[dict[str, int]] = [{} for _start in bucket_starts]
+        for row in model_rows or []:
+            try:
+                minute = int(row.get("minute", -1))
+                total = sum(
+                    max(0, int(row.get(field, 0) or 0))
+                    for field in (
+                        "cache_hit_tokens",
+                        "cache_miss_tokens",
+                        "output_tokens",
+                    )
+                )
+            except (TypeError, ValueError):
+                continue
+            if not 0 <= minute < 1440:
+                continue
+            model = str(row.get("model") or "unknown").strip() or "unknown"
+            bucket = model_totals[minute // interval_minutes]
+            bucket[model] = bucket.get(model, 0) + total
+        model_names = [
+            sorted(totals, key=lambda model: (-totals[model], model))
+            for totals in model_totals
+        ]
         signature = (
             status,
             chart_type,
             interval_minutes,
             currency,
             tuple(tuple(values[key]) for key, _label in self.SERIES),
+            tuple(tuple(names) for names in model_names),
         )
         self._chart_type = chart_type
         self._currency = str(currency or "CNY").upper()
@@ -1295,6 +1738,7 @@ class MinuteUsageChart(QWidget):
         ]
         self._values = values
         self._cost_values = cost_values
+        self._model_names = model_names
         if loading and not rows:
             self._show_state("正在刷新分时数据…")
             return
@@ -1801,8 +2245,12 @@ class MinuteUsageChart(QWidget):
             values,
             self._cost_values[bucket_index],
             self._currency,
+            self._model_names[bucket_index],
         )
-        self.hover_tooltip.adjustSize()
+        tooltip_layout = self.hover_tooltip.layout()
+        if tooltip_layout is not None:
+            tooltip_layout.activate()
+        self.hover_tooltip.resize(self.hover_tooltip.sizeHint())
         x = local.x() + 10
         if x + self.hover_tooltip.width() > self.plot.width() - 6:
             x = local.x() - self.hover_tooltip.width() - 10
@@ -1833,8 +2281,11 @@ class MinuteUsageChart(QWidget):
         cost_name = (
             "本分钟消耗金额" if self._interval_minutes == 1 else "本时段消耗金额"
         )
+        models = self._model_names[bucket_index]
+        model_line = f"模型　{'、'.join(models)}\n" if models else ""
         return (
             f"{self._bucket_time_text(bucket_index)}　总计 {total:,}\n"
+            f"{model_line}"
             f"■ 输入（命中缓存）　{hit:,}\n"
             f"■ 输入（未命中缓存）　{miss:,}\n"
             f"■ 输出　{output:,}\n"
@@ -1998,10 +2449,12 @@ class MainPanel(QFrame):
         self._minute_current_date = ""
         self._minute_current_rows: list[dict] = []
         self._minute_current_cost_rows: list[dict] = []
+        self._minute_current_model_rows: list[dict] = []
         self._minute_current_status = "unavailable"
         self._minute_usage_source = ""
         self._minute_usage_history: dict[str, list[dict]] = {}
         self._minute_cost_usage_history: dict[str, list[dict]] = {}
+        self._minute_model_usage_history: dict[str, list[dict]] = {}
         self._minute_usage_days: list[str] = []
         self._minute_selected_date = ""
         self._minute_follows_latest = True
@@ -2408,10 +2861,12 @@ class MainPanel(QFrame):
         self._minute_current_date = data.minute_usage_date
         self._minute_current_rows = data.minute_usage
         self._minute_current_cost_rows = data.minute_cost_usage
+        self._minute_current_model_rows = data.minute_model_usage
         self._minute_current_status = data.minute_usage_status
         self._minute_usage_source = data.minute_usage_source
         self._minute_usage_history = dict(data.minute_usage_history)
         self._minute_cost_usage_history = dict(data.minute_cost_usage_history)
+        self._minute_model_usage_history = dict(data.minute_model_usage_history)
         self._minute_usage_days = []
 
         current_date = QDate.fromString(data.minute_usage_date, "yyyy-MM-dd")
@@ -2496,6 +2951,7 @@ class MainPanel(QFrame):
         if selected_date == self._minute_current_date:
             rows = self._minute_current_rows
             cost_rows = self._minute_current_cost_rows
+            model_rows = self._minute_current_model_rows
             status = self._minute_current_status
             status_hint = {
                 "failed": "；刷新失败，当前显示最近结果",
@@ -2506,6 +2962,7 @@ class MainPanel(QFrame):
         else:
             rows = self._minute_usage_history.get(selected_date, [])
             cost_rows = self._minute_cost_usage_history.get(selected_date, [])
+            model_rows = self._minute_model_usage_history.get(selected_date, [])
             status = "recorded" if rows else "empty"
             tooltip = f"选择分时日期；当前查看 {selected_date}"
         try:
@@ -2530,6 +2987,7 @@ class MainPanel(QFrame):
             interval_minutes=interval_minutes,
             chart_type=chart_type,
             currency=self._currency,
+            model_rows=model_rows,
         )
         self.activity_summary.setText(
             self.minute_chart.summary_text()
@@ -2813,6 +3271,7 @@ class MainPanel(QFrame):
                 data.weekly_usage or data.daily_usage,
                 currency=self._currency,
                 token_mode=True,
+                provider_id=provider_id,
             )
             weekly_tooltip = {
                 "interface": f"来自 {provider_name} 账号统计",
@@ -2822,7 +3281,8 @@ class MainPanel(QFrame):
                 "local": "接口统计暂不可用；仅当天 Token 来自本机会话日志估算",
             }.get(data.weekly_activity_source, "")
             self.trend.title.setToolTip(weekly_tooltip)
-            self.trend.plot.setToolTip(weekly_tooltip)
+            self.trend.title.setAccessibleDescription(weekly_tooltip)
+            self.trend.plot.setToolTip("")
             self._activity_view = "annual"
             self.activity_stack.setCurrentIndex(0)
             self.annual_activity_button.setChecked(True)
@@ -2894,7 +3354,33 @@ class MainPanel(QFrame):
             button.setEnabled(data.minute_usage_status != "unavailable")
         self._refresh_minute_control_colors()
 
-        self.trend.set_rows(data.daily_usage, currency=self._currency)
+        trend_today = None
+        if provider_id == "nayuto" and data.minute_usage_date:
+            try:
+                trend_today = date.fromisoformat(data.minute_usage_date)
+            except ValueError:
+                trend_today = None
+        model_usage_enabled = bool(
+            provider_cls and getattr(provider_cls, "supports_model_usage", False)
+        )
+        self.trend.set_rows(
+            data.daily_usage,
+            today=trend_today,
+            currency=self._currency,
+            model_rows=data.daily_model_usage,
+            model_usage_enabled=model_usage_enabled,
+            provider_id=provider_id,
+        )
+        trend_source = (
+            "当前显示最近一次缓存的近 7 天数据"
+            if provider_id == "nayuto" and data.is_stale
+            else "来自 NayutoAI 用量明细"
+            if provider_id == "nayuto"
+            else ""
+        )
+        self.trend.title.setToolTip(trend_source)
+        self.trend.title.setAccessibleDescription(trend_source)
+        self.trend.plot.setToolTip("")
         self.statistics.set_data(data)
         status, _color = self.status_summary(data, loading or refreshing)
         self.status_text.setText(status)

--- a/ui/qt_panel.py
+++ b/ui/qt_panel.py
@@ -60,6 +60,7 @@ from core.identity import APP_DISPLAY_NAME
 from data.store import TokenData
 from ui.activity import compact_tokens
 from ui.formatting import (
+    format_codex_reset_time,
     format_codex_tokens,
     format_minute_money,
     format_money,
@@ -3229,9 +3230,14 @@ class MainPanel(QFrame):
                 if not (provider_id == "codex" and is_codex_spark_quota(window.title))
             ]
             for window in visible_windows[:3]:
+                reset_text = (
+                    format_codex_reset_time(window.resets_at)
+                    if provider_id == "codex"
+                    else format_reset_countdown(window.resets_at)
+                )
                 detail_parts = [
                     f"剩余 {100 - window.used_percent:.0f}%",
-                    format_reset_countdown(window.resets_at),
+                    reset_text,
                 ]
                 if window.detail:
                     detail_parts.append(window.detail)

--- a/ui/qt_widget.py
+++ b/ui/qt_widget.py
@@ -30,7 +30,7 @@ from api.providers.mimo import MiMoProvider
 from config import runtime as config_manager
 from core.identity import APP_DISPLAY_NAME
 from data.store import PerProviderData, TokenData
-from ui.formatting import format_money, format_reset_countdown
+from ui.formatting import format_codex_reset_time, format_money, format_reset_countdown
 from ui.geometry import (
     WorkArea,
     clamp_window,
@@ -1321,9 +1321,14 @@ class FloatingWidget(QWidget):
         )
         if self._data.quota_windows:
             primary = self._data.quota_windows[0]
+            reset_text = (
+                format_codex_reset_time(primary.resets_at, compact=True)
+                if provider_id == "codex"
+                else format_reset_countdown(primary.resets_at)
+            )
             self.ball.set_quota_state(
                 None if loading else 100 - primary.used_percent,
-                "正在更新额度" if loading else format_reset_countdown(primary.resets_at),
+                "正在更新额度" if loading else reset_text,
                 primary.title,
             )
         elif quota_mode:


### PR DESCRIPTION
## 修改类型

- [x] 功能新增
- [x] Bug 修复
- [x] 功能优化
- [ ] 代码重构
- [ ] 文档更新

## 修改内容

- 新增 NayutoAI 近 7 天各模型 Token 分组柱状图及悬停明细。
- 今日分时 Tooltip 增加模型名称，并修复提示框裁切、模型换行及提示框争用。
- 单模型柱状图复用当前主题强调色，多模型保留稳定区分色。
- Codex 重置时间改为北京时间的月日时分绝对时间。

## 影响范围

- NayutoAI 用量解析、分钟与日模型聚合。
- 主面板近 7 天趋势图和今日分时 Tooltip。
- Codex 额度卡片与悬浮球重置时间。
- Cursor 和其他 Provider 保持原倒计时及原有行为。

## 验证结果

- 全量测试：413 passed, 20 subtests passed。
- Qt UI 测试：138 passed。
- Ruff：通过。
- Pyright：0 errors, 0 warnings。
- git diff --check：通过。

## 版本变化

普通开发提交，本次不更新公开版本号，不创建 Tag 或 Release。